### PR TITLE
Add Claude Code account providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,53 @@ Variants set the underlying reasoning effort. They're regular opencode model var
 
 The minimum config is just the `plugin` entry above. Everything below is optional override that goes in a `provider.claude-code` block.
 
+### Multiple Claude Code accounts
+
+Declare account names once and the plugin expands them into separate opencode providers:
+
+```json
+{
+  "plugin": ["@khalilgharbaoui/opencode-claude-code-plugin"],
+  "provider": {
+    "claude-code": {
+      "options": {
+        "accounts": ["personal", "work"]
+      }
+    }
+  }
+}
+```
+
+`default` is always implicit, so the config above creates:
+
+| Provider ID | Display name | Claude config dir |
+|---|---|---|
+| `claude-code-default` | `Claude Code (Default)` | normal `~/.claude` |
+| `claude-code-personal` | `Claude Code (Personal)` | `~/.claude-personal` |
+| `claude-code-work` | `Claude Code (Work)` | `~/.claude-work` |
+
+Non-default accounts use `CLAUDE_CONFIG_DIR` through a generated wrapper script, so auth/session state stays isolated per account. Shared capability files and folders are symlinked from `~/.claude` into each account dir when present:
+
+```text
+CLAUDE.md
+settings.json
+skills/
+agents/
+commands/
+plugins/
+```
+
+Identity/session state is not shared.
+
+Login each account once:
+
+```bash
+CLAUDE_CONFIG_DIR="$HOME/.claude-personal" claude auth login
+CLAUDE_CONFIG_DIR="$HOME/.claude-work" claude auth login
+```
+
+The account model IDs are internally suffixed, for example `claude-sonnet-4-6@work`, so long-lived Claude subprocess sessions do not collide across accounts. The generated wrapper strips the suffix before calling `claude --model`.
+
 ### Options reference
 
 ```json
@@ -112,6 +159,7 @@ The minimum config is just the `plugin` entry above. Everything below is optiona
 | Option | Type | Default | Description |
 |---|---|---|---|
 | `cliPath` | string | `process.env.CLAUDE_CLI_PATH ?? "claude"` | Path to the `claude` binary. |
+| `accounts` | string[] | – | Optional account list. `default` is implicit. Expands into `Claude Code (Default)`, `Claude Code (Personal)`, etc. |
 | `cwd` | string | `process.cwd()` | Working directory for the spawned CLI. Resolved **lazily per request**, so opencode's project switching works. |
 | `skipPermissions` | boolean | `true` | Pass `--dangerously-skip-permissions` to `claude`. Ignored when `proxyTools` is set — the proxy handles permissions through opencode instead. |
 | `permissionMode` | `acceptEdits` \| `auto` \| `bypassPermissions` \| `default` \| `dontAsk` \| `plan` | – | Forwarded to `claude --permission-mode`. |
@@ -221,7 +269,7 @@ To replace (rather than augment) bridged MCP with your own:
 
 Each chat keeps a long-lived `claude` subprocess so the model retains its native context across turns.
 
-- **Session key**: `(cwd, model, tool-scope, opencode-session-id)`. The opencode session id comes from the `x-session-affinity` header opencode sets on third-party provider calls. Two chats in the same project on the same model run in **separate** CLI processes — they don't race.
+- **Session key**: `(cwd, model, tool-scope, opencode-session-id)`. The opencode session id comes from the `x-session-affinity` header opencode sets on third-party provider calls. Two chats in the same project on the same model run in **separate** CLI processes — they don't race. In account mode, model IDs are suffixed per account, so account sessions do not collide.
 - **Same chat, multiple turns** → process reused, full Claude context retained.
 - **New chat** → fresh process under the new session key.
 - **Resumed chat after restart** → in-memory state is gone; a new process spawns and the conversation history is summarized and prepended.

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -162,7 +162,7 @@ while [[ $# -gt 0 ]]; do
   if [[ "$1" == "--model" && $# -ge 2 ]]; then
     model="$2"
     if [[ "$model" == *${shellDoubleQuote(suffix)} ]]; then
-      model="${model%${shellDoubleQuote(suffix)}}"
+      model="\${model%${shellDoubleQuote(suffix)}}"
     fi
     args+=("$1" "$model")
     shift 2
@@ -173,7 +173,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 export CLAUDE_CONFIG_DIR=${shellSingleQuote(configDir)}
-exec ${shellSingleQuote(baseCliPath)} "${args[@]}"
+exec ${shellSingleQuote(baseCliPath)} "\${args[@]}"
 `
 
   await writeFile(wrapperPath, script, "utf8")

--- a/src/accounts.ts
+++ b/src/accounts.ts
@@ -1,0 +1,199 @@
+import { chmod, lstat, mkdir, readlink, symlink, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { log } from "./logger.js"
+
+export const BASE_PROVIDER_ID = "claude-code"
+export const DEFAULT_ACCOUNT = "default"
+
+const SHARED_CAPABILITY_ITEMS = [
+  "CLAUDE.md",
+  "settings.json",
+  "skills",
+  "agents",
+  "commands",
+  "plugins",
+]
+
+export function normalizeAccountName(account: string): string {
+  return account
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+}
+
+export function resolveAccounts(value: unknown): string[] | null {
+  if (!Array.isArray(value)) return null
+
+  const accounts = value
+    .map((account) => normalizeAccountName(String(account)))
+    .filter(Boolean)
+
+  return Array.from(new Set([DEFAULT_ACCOUNT, ...accounts]))
+}
+
+export function accountProviderId(account: string): string {
+  return `${BASE_PROVIDER_ID}-${normalizeAccountName(account)}`
+}
+
+export function accountDisplayName(account: string): string {
+  return `Claude Code (${titleizeAccount(account)})`
+}
+
+export function accountModelSuffix(account: string): string | undefined {
+  const normalized = normalizeAccountName(account)
+  return normalized === DEFAULT_ACCOUNT ? undefined : normalized
+}
+
+export function accountConfigDir(account: string): string | undefined {
+  const normalized = normalizeAccountName(account)
+
+  if (!normalized || normalized === DEFAULT_ACCOUNT) return undefined
+
+  return `~/.claude-${normalized}`
+}
+
+export function expandHome(value: string): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE
+
+  if (value === "~") return home ?? value
+
+  if (value.startsWith("~/") || value.startsWith("~\\")) {
+    return home ? path.join(home, value.slice(2)) : value
+  }
+
+  return value
+}
+
+export async function ensureAccountRuntime(
+  account: string,
+  baseCliPath: string,
+): Promise<{ cliPath: string; configDir?: string }> {
+  const configDir = accountConfigDir(account)
+
+  if (!configDir) return { cliPath: baseCliPath }
+
+  const expandedConfigDir = expandHome(configDir)
+  await mkdir(expandedConfigDir, { recursive: true })
+  await ensureSharedCapabilities(expandedConfigDir)
+
+  const cliPath = await writeAccountWrapper(
+    normalizeAccountName(account),
+    baseCliPath,
+    expandedConfigDir,
+  )
+
+  return { cliPath, configDir }
+}
+
+async function ensureSharedCapabilities(targetRoot: string): Promise<void> {
+  const sourceRoot = expandHome("~/.claude")
+
+  for (const item of SHARED_CAPABILITY_ITEMS) {
+    await ensureSharedCapabilityItem(sourceRoot, targetRoot, item)
+  }
+}
+
+async function ensureSharedCapabilityItem(
+  sourceRoot: string,
+  targetRoot: string,
+  item: string,
+): Promise<void> {
+  const source = path.join(sourceRoot, item)
+  const target = path.join(targetRoot, item)
+
+  let sourceStat
+  try {
+    sourceStat = await lstat(source)
+  } catch {
+    return
+  }
+
+  try {
+    const targetStat = await lstat(target)
+
+    if (targetStat.isSymbolicLink()) {
+      const current = await readlink(target)
+      const resolvedCurrent = path.resolve(path.dirname(target), current)
+      const resolvedSource = path.resolve(source)
+
+      if (resolvedCurrent === resolvedSource) return
+    }
+
+    log.warn("shared Claude capability already exists; leaving untouched", {
+      item,
+      target,
+      source,
+    })
+
+    return
+  } catch {
+    // Missing target is expected.
+  }
+
+  const type = sourceStat.isDirectory()
+    ? process.platform === "win32"
+      ? "junction"
+      : "dir"
+    : "file"
+
+  await symlink(source, target, type)
+}
+
+async function writeAccountWrapper(
+  account: string,
+  baseCliPath: string,
+  configDir: string,
+): Promise<string> {
+  const cacheRoot = path.join(
+    process.env.XDG_CACHE_HOME ?? expandHome("~/.cache"),
+    "opencode-claude-code-plugin",
+  )
+  const wrapperPath = path.join(cacheRoot, `claude-${account}`)
+  const suffix = `@${account}`
+
+  await mkdir(cacheRoot, { recursive: true })
+
+  const script = `#!/usr/bin/env bash
+set -euo pipefail
+
+args=()
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--model" && $# -ge 2 ]]; then
+    model="$2"
+    if [[ "$model" == *${shellDoubleQuote(suffix)} ]]; then
+      model="${model%${shellDoubleQuote(suffix)}}"
+    fi
+    args+=("$1" "$model")
+    shift 2
+  else
+    args+=("$1")
+    shift
+  fi
+done
+
+export CLAUDE_CONFIG_DIR=${shellSingleQuote(configDir)}
+exec ${shellSingleQuote(baseCliPath)} "${args[@]}"
+`
+
+  await writeFile(wrapperPath, script, "utf8")
+  await chmod(wrapperPath, 0o755)
+
+  return wrapperPath
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`
+}
+
+function shellDoubleQuote(value: string): string {
+  return value.replace(/[$`"\\]/g, "\\$&")
+}
+
+function titleizeAccount(account: string): string {
+  return normalizeAccountName(account)
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ")
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,14 @@ import { ClaudeCodeLanguageModel } from "./claude-code-language-model.js"
 import { defaultModels } from "./models.js"
 import type { OpenCodePlugin, OpenCodeProvider } from "./opencode-types.js"
 import type { ClaudeCodeProviderSettings } from "./types.js"
+import {
+  BASE_PROVIDER_ID,
+  accountDisplayName,
+  accountModelSuffix,
+  accountProviderId,
+  ensureAccountRuntime,
+  resolveAccounts,
+} from "./accounts.js"
 
 export interface ClaudeCodeProvider {
   specificationVersion: "v3"
@@ -15,7 +23,7 @@ export function createClaudeCode(
 ): ClaudeCodeProvider {
   const cliPath =
     settings.cliPath ?? process.env.CLAUDE_CLI_PATH ?? "claude"
-  const providerName = settings.name ?? "claude-code"
+  const providerName = settings.providerID ?? settings.name ?? "claude-code"
   const proxyTools = settings.proxyTools ?? ["Bash", "Edit", "Write", "WebFetch"]
 
   const createModel = (modelId: string): LanguageModelV3 => {
@@ -23,6 +31,9 @@ export function createClaudeCode(
       provider: providerName,
       cliPath,
       cwd: settings.cwd,
+      account: settings.account,
+      configDir: settings.configDir,
+      providerID: settings.providerID,
       skipPermissions: settings.skipPermissions ?? true,
       permissionMode: settings.permissionMode,
       mcpConfig: settings.mcpConfig,
@@ -49,11 +60,19 @@ export function createClaudeCode(
 // OpenCode plugin interface
 // ---------------------------------------------------------------------------
 
-const PROVIDER_ID = "claude-code"
+const PROVIDER_ID = BASE_PROVIDER_ID
 const PACKAGE_NPM = "@khalilgharbaoui/opencode-claude-code-plugin"
 
 function pluginEntrypoint(): string {
   return import.meta.url.startsWith("file:") ? import.meta.url : PACKAGE_NPM
+}
+
+function cleanProviderOptions(
+  options: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const result = { ...options }
+  delete result.accounts
+  return result
 }
 
 function mergeDefaultVariants(models: Record<string, unknown> = {}) {
@@ -81,16 +100,24 @@ function mergeDefaultVariants(models: Record<string, unknown> = {}) {
   return result
 }
 
-function defaultModelsForProvider(providerModels: OpenCodeProvider["models"]) {
+function defaultModelsForProvider(
+  providerModels: OpenCodeProvider["models"],
+  providerID = PROVIDER_ID,
+  modelSuffix?: string,
+) {
   const models = Object.fromEntries(
     Object.entries(defaultModels).map(([id, model]) => {
-      const existing = providerModels[id]
+      const modelId = modelSuffix ? `${id}@${modelSuffix}` : id
+      const existing = providerModels[id] ?? providerModels[modelId]
       return [
-        id,
+        modelId,
         {
           ...model,
+          id: modelId,
+          providerID,
           api: {
             ...model.api,
+            id: modelId,
             npm: existing?.api?.npm ?? model.api.npm,
             url: existing?.api?.url ?? model.api.url,
           },
@@ -100,37 +127,113 @@ function defaultModelsForProvider(providerModels: OpenCodeProvider["models"]) {
   )
 
   for (const [id, model] of Object.entries(providerModels)) {
-    if (!(id in models)) models[id] = model
+    if (!(id in models)) {
+      models[id] = {
+        ...model,
+        providerID,
+      }
+    }
   }
 
   return models
 }
 
-function providerConfig(existing?: {
-  name?: string
-  npm?: string
-  options?: Record<string, unknown>
-  models?: Record<string, unknown>
-}) {
+async function providerConfig(
+  existing: {
+    name?: string
+    npm?: string
+    options?: Record<string, unknown>
+    models?: Record<string, unknown>
+  } | undefined,
+  providerID = PROVIDER_ID,
+  optionDefaults: Record<string, unknown> = {},
+  displayName?: string,
+) {
+  const mergedOptions = {
+    cliPath: "claude",
+    proxyTools: ["Bash", "Edit", "Write", "WebFetch"],
+    ...optionDefaults,
+    ...cleanProviderOptions(existing?.options),
+    providerID,
+  }
+
+  const cliPath = String(mergedOptions.cliPath ?? "claude")
+  const account =
+    typeof mergedOptions.account === "string" ? mergedOptions.account : undefined
+  const runtime = account
+    ? await ensureAccountRuntime(account, cliPath)
+    : { cliPath }
+
   return {
-    name: existing?.name,
+    name: displayName ?? existing?.name,
     npm: existing?.npm ?? pluginEntrypoint(),
     options: {
-      cliPath: "claude",
-      proxyTools: ["Bash", "Edit", "Write", "WebFetch"],
-      ...(existing?.options ?? {}),
+      ...mergedOptions,
+      ...runtime,
     },
     models: mergeDefaultVariants(existing?.models),
   }
 }
 
+async function expandAccountProviders(config: {
+  provider?: Record<
+    string,
+    {
+      name?: string
+      npm?: string
+      options?: Record<string, unknown>
+      models?: Record<string, unknown>
+    }
+  >
+}): Promise<boolean> {
+  const seed = config.provider?.[PROVIDER_ID]
+  const accounts = resolveAccounts(seed?.options?.accounts)
+
+  if (!accounts) return false
+
+  config.provider ??= {}
+
+  const seedOptions = cleanProviderOptions(seed?.options)
+
+  for (const account of accounts) {
+    const providerID = accountProviderId(account)
+    const existing = config.provider[providerID]
+    const modelSuffix = accountModelSuffix(account)
+
+    config.provider[providerID] = {
+      ...existing,
+      ...(await providerConfig(
+        existing,
+        providerID,
+        {
+          ...seedOptions,
+          account,
+        },
+        accountDisplayName(account),
+      )),
+      models: defaultModelsForProvider(
+        (existing?.models ?? seed?.models ?? {}) as OpenCodeProvider["models"],
+        providerID,
+        modelSuffix,
+      ),
+    }
+  }
+
+  delete config.provider[PROVIDER_ID]
+  return true
+}
+
 const server: OpenCodePlugin = async () => ({
   config: async (config) => {
     config.provider ??= {}
+
+    const expanded = await expandAccountProviders(config)
+    if (expanded) return
+
     const existing = config.provider[PROVIDER_ID]
     config.provider[PROVIDER_ID] = {
       ...existing,
-      ...providerConfig(existing),
+      ...(await providerConfig(existing)),
     }
   },
   provider: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,9 @@ export interface ClaudeCodeConfig {
   provider: string
   cliPath: string
   cwd?: string
+  account?: string
+  configDir?: string
+  providerID?: string
   skipPermissions?: boolean
   permissionMode?: PermissionMode
   mcpConfig?: string | string[]
@@ -17,6 +20,10 @@ export interface ClaudeCodeProviderSettings {
   cliPath?: string
   cwd?: string
   name?: string
+  providerID?: string
+  account?: string
+  configDir?: string
+  accounts?: string[]
   skipPermissions?: boolean
   permissionMode?: PermissionMode
   mcpConfig?: string | string[]


### PR DESCRIPTION
## Summary

Adds low-config Claude Code account support to the OpenCode provider plugin.

With this config:

```json
{
  "plugin": ["@khalilgharbaoui/opencode-claude-code-plugin"],
  "provider": {
    "claude-code": {
      "options": {
        "accounts": ["personal", "work"]
      }
    }
  }
}
```

the plugin expands providers dynamically:

- `claude-code-default` → `Claude Code (Default)` → normal `~/.claude`
- `claude-code-personal` → `Claude Code (Personal)` → `~/.claude-personal`
- `claude-code-work` → `Claude Code (Work)` → `~/.claude-work`

## Details

- Adds `src/accounts.ts` for account name normalization, provider/display naming, config-dir resolution, wrapper generation, and shared capability symlinks.
- Keeps `default` implicit even when not listed in `accounts`.
- Uses `~/.claude-{account}` for non-default accounts.
- Shares capability files/folders from `~/.claude` into account dirs when present:
  - `CLAUDE.md`
  - `settings.json`
  - `skills/`
  - `agents/`
  - `commands/`
  - `plugins/`
- Generates account-specific wrapper scripts under `$XDG_CACHE_HOME/opencode-claude-code-plugin` or `~/.cache/opencode-claude-code-plugin`.
- Uses account-suffixed model IDs, e.g. `claude-sonnet-4-6@work`, to avoid long-lived subprocess/session collisions across accounts.
- Wrapper strips the account suffix before calling `claude --model`.
- Documents login/setup and runtime behavior in README.

## Notes

I could not run `bun run typecheck` from this environment because the repo is only available through the GitHub connector, not as a local checkout. Please run locally before merge:

```bash
bun install
bun run typecheck
bun run build
```
