### PR TITLE
feat(proxy): expose Task as a proxied tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ By default, when Claude Code's CLI uses `Bash`, `Edit`, `Write`, etc., it execut
 
 The `Task` proxy is the way to let Claude orchestrate opencode's configured subagents (`build`, `general`, custom subagents defined in `opencode.json`) instead of Claude CLI's internal-only general-purpose / Explore / Plan options. With `"Task"` in `proxyTools` and `permission.task: allow` granted to the calling agent, a Claude session can invoke `task(subagent_type="build", prompt="...")` and the subagent runs natively under opencode (with its own permission UI, lifecycle, model assignment, and Tab visibility). Without `"Task"`, Claude's built-in `Agent` tool stays enabled and Claude orchestrates subagents internally with no opencode visibility.
 
-Only those four values are actually proxied; anything else you put in `proxyTools` is ignored. Proxying `Edit` also disables `MultiEdit` — opencode has no batched-edit equivalent, so Claude is forced to fan out into single `Edit` calls that each flow through the permission UI.
+Only those five values are actually proxied; anything else you put in `proxyTools` is ignored. Proxying `Edit` also disables `MultiEdit` — opencode has no batched-edit equivalent, so Claude is forced to fan out into single `Edit` calls that each flow through the permission UI.
 
 To turn off proxying entirely:
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ By default, when Claude Code's CLI uses `Bash`, `Edit`, `Write`, etc., it execut
 | `"Edit"` | `Edit`, `MultiEdit` | `mcp__opencode_proxy__edit` |
 | `"Write"` | `Write` | `mcp__opencode_proxy__write` |
 | `"WebFetch"` | `WebFetch` | `mcp__opencode_proxy__webfetch` |
+| `"Task"` | `Agent` | `mcp__opencode_proxy__task` |
+
+The `Task` proxy is the way to let Claude orchestrate opencode's configured subagents (`build`, `general`, custom subagents defined in `opencode.json`) instead of Claude CLI's internal-only general-purpose / Explore / Plan options. With `"Task"` in `proxyTools` and `permission.task: allow` granted to the calling agent, a Claude session can invoke `task(subagent_type="build", prompt="...")` and the subagent runs natively under opencode (with its own permission UI, lifecycle, model assignment, and Tab visibility). Without `"Task"`, Claude's built-in `Agent` tool stays enabled and Claude orchestrates subagents internally with no opencode visibility.
 
 Only those four values are actually proxied; anything else you put in `proxyTools` is ignored. Proxying `Edit` also disables `MultiEdit` — opencode has no batched-edit equivalent, so Claude is forced to fan out into single `Edit` calls that each flow through the permission UI.
 

--- a/src/proxy-mcp.ts
+++ b/src/proxy-mcp.ts
@@ -158,6 +158,46 @@ export const DEFAULT_PROXY_TOOLS: ProxyToolDef[] = [
       required: ["url"],
     },
   },
+  {
+    name: "task",
+    description:
+      "Launch an opencode subagent to handle a complex multi-step task" +
+      " autonomously. Routed through opencode's task tool so subagent" +
+      " orchestration, permission, and lifecycle are handled by opencode." +
+      " Use `subagent_type` to pick which configured subagent runs (e.g." +
+      " `build`, `general`, `explore`, or any custom subagent declared in" +
+      " opencode.json). The call blocks until the subagent finishes; the" +
+      " 10-minute proxy timeout applies.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        description: {
+          type: "string",
+          description: "A short (3-5 words) description of the task",
+        },
+        prompt: {
+          type: "string",
+          description: "The task for the agent to perform",
+        },
+        subagent_type: {
+          type: "string",
+          description: "The type of specialized agent to use for this task",
+        },
+        task_id: {
+          type: "string",
+          description:
+            "Set this only if you mean to resume a previous task — pass the" +
+            " prior task_id to continue the same subagent session instead of" +
+            " creating a fresh one.",
+        },
+        command: {
+          type: "string",
+          description: "The command that triggered this task",
+        },
+      },
+      required: ["description", "prompt", "subagent_type"],
+    },
+  },
 ]
 
 export async function createProxyMcpServer(
@@ -435,6 +475,12 @@ export function disallowedToolFlags(tools: ProxyToolDef[]): string[] {
   // `edit` covers both `Edit` and `MultiEdit` because opencode has no
   // MultiEdit equivalent; without disabling MultiEdit, Claude can batch
   // file changes through it and bypass opencode's permission UI.
+  // `task` disables Claude CLI's `Agent` tool (its built-in subagent
+  // dispatcher) so subagent calls flow through opencode's `task` tool
+  // instead — which lets opencode's configured subagent set (`build`,
+  // `general`, custom subagents in opencode.json) execute the work
+  // under opencode's permission/lifecycle, rather than Claude's
+  // internal-only general-purpose / Explore / Plan options.
   const nameMap: Record<string, string[]> = {
     bash: ["Bash"],
     read: ["Read"],
@@ -443,6 +489,7 @@ export function disallowedToolFlags(tools: ProxyToolDef[]): string[] {
     glob: ["Glob"],
     grep: ["Grep"],
     webfetch: ["WebFetch"],
+    task: ["Agent"],
   }
   const out: string[] = []
   const seen = new Set<string>()

--- a/src/types.ts
+++ b/src/types.ts
@@ -108,7 +108,15 @@ export interface ClaudeCodeProviderSettings {
    *     opencode's tool executor (with its native permission UI) and returns
    *     the result.
    *
-   * Supported: `bash`, `write`, `edit`, `webfetch`. Leave empty or unset to disable proxying.
+   * Supported: `bash`, `write`, `edit`, `webfetch`, `task`. Leave empty or unset to disable proxying.
+   *
+   * `task` proxies Claude CLI's `Agent` (subagent dispatch) tool through
+   * opencode's `task` tool, so subagent calls run under opencode's
+   * configured subagent set (build/general/custom) with opencode's
+   * permission and lifecycle handling, instead of Claude CLI's
+   * internal-only general-purpose / Explore / Plan options. The calling
+   * agent must have `permission.task: allow` for the target subagent
+   * (see opencode's agent docs).
    */
   proxyTools?: string[]
 


### PR DESCRIPTION
Adds `task` to DEFAULT_PROXY_TOOLS so users can opt into routing Claude CLI's `Agent` (built-in subagent dispatcher) through opencode's native `task` tool. With `"Task"` in proxyTools and `permission.task: allow` on the calling agent, Claude can invoke
`task(subagent_type="build", prompt="...")` and the subagent runs under opencode — using the configured subagent set (`build`, `general`, custom subagents in opencode.json) with opencode's permission UI, lifecycle, and model assignment — instead of Claude's internal-only general-purpose / Explore / Plan options.

Mechanism is identical to the existing four (bash/edit/write/webfetch):

1. Claude calls `mcp__opencode_proxy__task` via --mcp-config
2. proxy-mcp.ts parks the HTTP request
3. The pending call drains into the AI SDK stream as a tool-call with `toolName: "task"` — matching opencode's native tool name
4. Opencode executes its native task tool, dispatches the subagent
5. The tool-result lands in the next prompt; extractPendingProxyResult matches by callId and resolves the parked MCP HTTP request

No opencode-side changes needed — opencode's native `task` tool is the executor, just like `bash` for the existing bash proxy.

Schema matches opencode's task tool (`description`, `prompt`, `subagent_type` required; `task_id`, `command` optional).

10-minute proxy timeout applies. Long subagent runs near that ceiling should treat the cap as a known constraint; future work could extend PROXY_CALL_TIMEOUT_MS per-tool.