### PR TITLE
fix(askuserquestion): render full question + options; never auto-allo…

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,32 @@ Set `permissionMode: "plan"` to forward `--permission-mode plan` to Claude. The 
 
 ---
 
+## AskUserQuestion
+
+opencode has no native structured ask-question executor to proxy through (unlike `Bash`/`Task`), so the plugin handles `AskUserQuestion` specially:
+
+1. **It renders the full question.** The tool's payload — every question, header, option label, and option description — is emitted as readable markdown into the assistant stream so the user actually sees the choices (same approach as `ExitPlanMode`).
+2. **It is never auto-allowed at the CLI gate.** Allowing it would let the headless Claude CLI resolve its own question (no TTY → fabricated/empty answer) and proceed on a guess. `controlRequestBehaviorForTool` hard-denies `AskUserQuestion` and returns a message telling the model to wait for the operator's answer — or, if the run is non-interactive, to proceed with the single most reasonable option and state its assumption rather than stall.
+
+This hard-deny sits **below** `controlRequestToolBehaviors` in precedence but **above** the global `controlRequestBehavior`. So:
+
+- The global `controlRequestBehavior: "allow"` does **not** override it (interactive setups stay correct by default).
+- An explicit per-tool entry **does**. For a fully unattended/automated deployment that prefers "guess and continue" over "stop and wait", restore the old auto-allow:
+
+  ```json
+  "provider": {
+    "claude-code": {
+      "options": {
+        "controlRequestToolBehaviors": { "AskUserQuestion": "allow" }
+      }
+    }
+  }
+  ```
+
+  With `"allow"`, the Claude CLI answers its own `AskUserQuestion` internally and the run never blocks — appropriate only when no operator is watching and forward progress matters more than a correct decision.
+
+---
+
 ## Compaction
 
 When you run `/compact` in opencode, the plugin handles it on a short-lived dedicated Claude CLI spawn instead of routing it through your main conversation process. Three reasons:

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -199,6 +199,71 @@ function normalizeVisibleText(text: string): string {
   return text.replace(/\s+/g, " ").trim()
 }
 
+/** Tool names that mean "ask the human a question" (CLI casing variants). */
+function isAskUserQuestionTool(name: string | undefined): boolean {
+  if (!name) return false
+  const n = name.toLowerCase()
+  return n === "askuserquestion" || n === "ask_user_question"
+}
+
+/**
+ * Render Claude Code's `AskUserQuestion` tool input as visible markdown.
+ *
+ * opencode has no native structured ask-question executor to proxy this
+ * through (unlike bash/task), so the question + every option is rendered
+ * as readable assistant text and the user answers in the next turn —
+ * same approach as the `ExitPlanMode` handling. The previous behavior
+ * collapsed the whole payload to a single faint `_Asking: <q>_` line,
+ * dropping all options and any question past the first.
+ */
+function formatAskUserQuestion(input: Record<string, unknown>): string {
+  const anyInput = input as any
+  const questions: any[] = Array.isArray(anyInput?.questions)
+    ? anyInput.questions
+    : []
+
+  if (questions.length === 0) {
+    const single = anyInput?.question ?? anyInput?.text
+    const q =
+      typeof single === "string" && single.trim() ? single.trim() : "Question?"
+    return `\n\n**${q}**\n\n_Reply with your answer to continue._\n\n`
+  }
+
+  const out: string[] = ["\n\n"]
+  const multiQ = questions.length > 1
+  questions.forEach((q, i) => {
+    const text =
+      (typeof q?.question === "string" && q.question.trim()) ||
+      (typeof q?.text === "string" && q.text.trim()) ||
+      "Question?"
+    const header =
+      typeof q?.header === "string" && q.header.trim() ? q.header.trim() : ""
+    out.push(`**${multiQ ? `${i + 1}. ` : ""}${text}**`)
+    if (header) out.push(` _(${header})_`)
+    out.push("\n\n")
+
+    const options: any[] = Array.isArray(q?.options) ? q.options : []
+    options.forEach((opt, j) => {
+      const label =
+        (typeof opt?.label === "string" && opt.label.trim()) ||
+        (typeof opt === "string" && opt.trim()) ||
+        `Option ${j + 1}`
+      const desc =
+        typeof opt?.description === "string" && opt.description.trim()
+          ? ` — ${opt.description.trim()}`
+          : ""
+      out.push(`${j + 1}. **${label}**${desc}\n`)
+    })
+
+    out.push(
+      q?.multiSelect === true
+        ? "\n_Select one or more — reply with the numbers or labels._\n\n"
+        : "\n_Reply with your choice (the number or label)._\n\n",
+    )
+  })
+  return out.join("")
+}
+
 function looksLikeQuestion(text: string): boolean {
   const normalized = normalizeVisibleText(text).toLowerCase()
   if (!normalized) return false
@@ -661,6 +726,15 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
       }
     }
 
+    // AskUserQuestion must never be auto-allowed. Allowing it lets the
+    // Claude CLI resolve its own question internally — in headless mode
+    // there is no TTY, so the CLI fabricates/empties the answer and the
+    // model proceeds on a guess. Deny so the CLI cannot self-answer; the
+    // tool_use is still streamed and rendered to the opencode user by
+    // formatAskUserQuestion, and the turn stops for a real reply. An
+    // explicit controlRequestToolBehaviors entry above can still override.
+    if (isAskUserQuestionTool(toolName)) return "deny"
+
     return this.config.controlRequestBehavior ?? "allow"
   }
 
@@ -716,11 +790,19 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
           toolName,
         })
       } else {
+        const denyMessage = isAskUserQuestionTool(toolName)
+          ? "Your question and its options have already been presented to" +
+            " the operator in full. Prefer to stop here and wait for their" +
+            " answer in the next message — do not silently guess. But if" +
+            " this is an automated or otherwise non-interactive run where" +
+            " no operator will reply, do not stall: proceed with the single" +
+            " most reasonable option and state, in one line, the assumption" +
+            " you made so it can be corrected later."
+          : this.config.controlRequestDenyMessage ??
+            `Denied by opencode-claude-code policy for tool ${toolName}`
         this.writeControlResponse(proc, requestId, {
           behavior: "deny",
-          message:
-            this.config.controlRequestDenyMessage ??
-            `Denied by opencode-claude-code policy for tool ${toolName}`,
+          message: denyMessage,
           toolUseID: request.tool_use_id,
         })
         log.info("control request auto-denied", {
@@ -1175,18 +1257,14 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                 thinkingText += block.thinking
               }
               if (block.type === "tool_use" && block.id && block.name) {
-                if (
-                  block.name === "AskUserQuestion" ||
-                  block.name === "ask_user_question"
-                ) {
-                  // Emit question as text
+                if (isAskUserQuestionTool(block.name)) {
+                  // Render the full question + options as visible text so
+                  // the user can actually see and answer it.
                   const parsedInput = (block.input ?? {}) as Record<
                     string,
                     unknown
                   >
-                  const question =
-                    (parsedInput?.question as string) || "Question?"
-                  responseText += `\n\n_Asking: ${question}_\n\n`
+                  responseText += formatAskUserQuestion(parsedInput)
                   continue
                 }
 
@@ -2073,32 +2151,12 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                   parsedInput = JSON.parse(tc.inputJson || "{}")
                 } catch {}
 
-                if (
-                  tc.name === "AskUserQuestion" ||
-                  tc.name === "ask_user_question"
-                ) {
-                  let question = "Question?"
-                  if (
-                    parsedInput?.questions &&
-                    Array.isArray(parsedInput.questions) &&
-                    parsedInput.questions.length > 0
-                  ) {
-                    question =
-                      parsedInput.questions[0].question ||
-                      parsedInput.questions[0].text ||
-                      "Question?"
-                  } else {
-                    question =
-                      parsedInput?.question ||
-                      parsedInput?.text ||
-                      "Question?"
-                  }
-
+                if (isAskUserQuestionTool(tc.name)) {
                   const askId = startTextBlock()
                   controller.enqueue({
                     type: "text-delta",
                     id: askId,
-                    delta: `\n\n_Asking: ${question}_\n\n`,
+                    delta: formatAskUserQuestion(parsedInput),
                   })
                   endTextBlock()
                 } else if (tc.name === "ExitPlanMode") {
@@ -2290,30 +2348,12 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                     input: parsedInput,
                   })
 
-                  if (
-                    block.name === "AskUserQuestion" ||
-                    block.name === "ask_user_question"
-                  ) {
-                    let question = "Question?"
-                    if (
-                      parsedInput?.questions &&
-                      Array.isArray(parsedInput.questions) &&
-                      parsedInput.questions.length > 0
-                    ) {
-                      const q = parsedInput.questions[0] as any
-                      question = q.question || q.text || "Question?"
-                    } else {
-                      question =
-                        (parsedInput?.question as string) ||
-                        (parsedInput?.text as string) ||
-                        "Question?"
-                    }
-
+                  if (isAskUserQuestionTool(block.name)) {
                     const askId = startTextBlock()
                     controller.enqueue({
                       type: "text-delta",
                       id: askId,
-                      delta: `\n\n_Asking: ${question}_\n\n`,
+                      delta: formatAskUserQuestion(parsedInput),
                     })
                     endTextBlock()
                   } else if (block.name === "ExitPlanMode") {


### PR DESCRIPTION
…w in CLI

Two problems made AskUserQuestion invisible/unanswerable under this plugin:

1. The tool_use was collapsed to a faint `_Asking: <q>_` line in three code paths — dropping every option, header, and any question past the first. Replaced with formatAskUserQuestion(): a shared renderer that emits all questions with headers, enumerated options + descriptions, and a single/multi-select reply hint as visible markdown (same approach as ExitPlanMode; opencode has no native structured ask-question executor to proxy through).

2. The CLI control gate auto-allowed AskUserQuestion, letting the headless Claude CLI resolve its own question with no TTY (fabricated or empty answer) and proceed on a guess. controlRequestBehaviorForTool now hard-denies AskUserQuestion (explicit controlRequestToolBehaviors config still overrides), with a specific deny message telling the model to stop and wait for the user. The tool_use is still streamed and rendered, and the turn stops for a real answer.

Re-applied on upstream v0.4.23 after the duplicate local Task-proxy commits were dropped (upstream shipped the identical feature as 9a31ae8 / PR #5, authored by galvani).