### PR TITLE
fix(provider): inject full model definitions via config hook

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -187,6 +187,10 @@ function configModelsForProvider(
   for (const [id, model] of Object.entries(defaultModels)) {
     const modelId = modelSuffix ? `${id}@${modelSuffix}` : id
     const existing = providerModels[id] ?? providerModels[modelId]
+    const existingVariants =
+      existing && typeof (existing as { variants?: unknown }).variants === "object"
+        ? ((existing as { variants?: Record<string, Record<string, unknown>> }).variants ?? {})
+        : {}
     const full: OpenCodeModel = {
       ...model,
       id: modelId,
@@ -196,6 +200,10 @@ function configModelsForProvider(
         id: modelId,
         npm: existing?.api?.npm ?? model.api.npm,
         url: existing?.api?.url ?? model.api.url,
+      },
+      variants: {
+        ...(model.variants ?? {}),
+        ...existingVariants,
       },
     }
     models[modelId] = toConfigModel(full)
@@ -347,6 +355,10 @@ const server: OpenCodePlugin = async (input) => {
       config.provider[PROVIDER_ID] = {
         ...existing,
         ...(await providerConfig(existing)),
+        models: configModelsForProvider(
+          (existing?.models ?? {}) as OpenCodeProvider["models"],
+          PROVIDER_ID,
+        ),
       }
       log.notice("registered claude-code provider", {
         id: PROVIDER_ID,


### PR DESCRIPTION
opencode loads plugin `provider.models` hooks before extending the provider database from config. For plugin-only providers — those that don't exist in the public models-dev catalog, e.g. `claude-code` — the `provider.models` hook bails (the `database[providerID]` lookup is empty), so model fields (limit, cost, family, name, capabilities, release_date) stay at their schema defaults of 0/empty/false.

Symptom: the session-context-usage indicator and context tab in the web UI show 0 / no percentage / no cost / no model name for any claude-code session, even though message tokens are populated correctly. Other providers (deepseek, anthropic, openai) render fine because their metadata is in models-dev.

`configModelsForProvider` already exists and produces models in the flat config schema opencode expects; it was wired into the multi-account expand path but not the default single-provider path. Adding it to the default config-hook output makes opencode see the real limits/costs/etc. when it builds the database from config, after the hooks have run.

Verified by hitting `/config/providers` before and after — claude-code now reports `limit.context`, `cost.input`, `family: "opus"`, `capabilities.reasoning: true`, etc. instead of zero/empty defaults.