### PR TITLE
feat: interactive subscription transport (Bun ConPTY)

### DIFF
--- a/e2e-claude-session-bun.ts
+++ b/e2e-claude-session-bun.ts
@@ -1,0 +1,97 @@
+/**
+ * E2E for src/claude-session-bun.ts against REAL claude over Bun's native
+ * ConPTY. Plain runnable script (not part of the offline suite; spawns claude,
+ * needs a logged-in subscription). Run:
+ *
+ *   bun e2e-claude-session-bun.ts
+ *
+ * Milestone proof: multiple messages in one live chat session, context retained
+ * across turns (subscription interactive path), with prompt-cache reuse.
+ */
+import { ClaudeSession, askOnce } from "./src/claude-session-bun.js"
+
+const TERMINAL = new Set(["end_turn", "stop_sequence", "max_tokens"])
+let failures = 0
+function check(cond: boolean, msg: string) {
+  if (cond) console.log("  PASS:", msg)
+  else {
+    failures++
+    console.log("  FAIL:", msg)
+  }
+}
+
+async function main() {
+  console.log("=== e2e claude-session-bun (Bun native ConPTY) ===")
+  console.log(
+    "bun:",
+    Bun.version,
+    "| Bun.Terminal:",
+    typeof (Bun as any).Terminal,
+  )
+
+  console.log("\n[A] one-shot 2+2")
+  const r = await askOnce("What is 2+2? Reply with only the number.", {
+    settingSources: "",
+  })
+  console.log("  reply:", JSON.stringify(r.text), "stop:", r.stopReason)
+  check(TERMINAL.has(r.stopReason ?? ""), "one-shot terminal stop")
+  check(/4/.test(r.text), "one-shot says 4")
+
+  console.log("\n[B] multi-turn: 3 messages, one live process")
+  const s = new ClaudeSession({ settingSources: "" })
+  await s.start()
+  try {
+    const t1 = await s.ask(
+      "Remember two facts for this conversation: my favorite number is 42 and my favorite color is teal. Reply with exactly: OK",
+    )
+    console.log("  turn1:", JSON.stringify(t1.text), "stop:", t1.stopReason)
+    check(TERMINAL.has(t1.stopReason ?? ""), "turn1 terminal stop")
+
+    const t2 = await s.ask(
+      "What is my favorite number? Reply with only the number.",
+    )
+    console.log(
+      "  turn2:",
+      JSON.stringify(t2.text),
+      "stop:",
+      t2.stopReason,
+      "cacheRead:",
+      t2.cacheReadTokens,
+      "eph1h:",
+      t2.ephemeral1hTokens,
+    )
+    check(TERMINAL.has(t2.stopReason ?? ""), "turn2 terminal stop")
+    check(/42/.test(t2.text), "turn2 recalls 42 (context retained across turns)")
+
+    const t3 = await s.ask(
+      "What is my favorite color? Reply with only the word.",
+    )
+    console.log(
+      "  turn3:",
+      JSON.stringify(t3.text),
+      "stop:",
+      t3.stopReason,
+      "cacheRead:",
+      t3.cacheReadTokens,
+    )
+    check(TERMINAL.has(t3.stopReason ?? ""), "turn3 terminal stop")
+    check(/teal/i.test(t3.text), "turn3 recalls teal (context retained across turns)")
+
+    check(
+      t2.cacheReadTokens > 0 || t3.cacheReadTokens > 0,
+      "prompt-cache reuse on later turns (1h tier)",
+    )
+  } finally {
+    s.dispose()
+  }
+
+  console.log(
+    `\n=== ${failures === 0 ? "ALL PASS" : failures + " FAILURE(S)"} ===`,
+  )
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main().catch((e) => {
+  console.error("FATAL:", e?.stack ?? e)
+  process.exit(2)
+})

--- a/src/bun-terminal.d.ts
+++ b/src/bun-terminal.d.ts
@@ -1,0 +1,35 @@
+// Minimal ambient types for the subset of Bun's native PTY API used by
+// claude-session-bun.ts. Kept local on purpose: pulling full `bun-types`
+// conflicts with `@types/node` in this repo, and we only need a few members.
+export {}
+
+declare global {
+  interface BunTerminal {
+    write(data: string | Uint8Array): number
+    close(): void
+    resize(cols: number, rows: number): void
+  }
+
+  interface BunSubprocess {
+    readonly terminal: BunTerminal
+    readonly exited: Promise<number>
+    readonly pid: number
+    kill(signal?: number | string): void
+  }
+
+  interface BunSpawnTerminalOptions {
+    cwd?: string
+    env?: Record<string, string | undefined>
+    terminal?: {
+      cols?: number
+      rows?: number
+      data?: (terminal: BunTerminal, data: Uint8Array) => void
+    }
+  }
+
+  const Bun: {
+    version: string
+    which(command: string, options?: { PATH?: string; cwd?: string }): string | null
+    spawn(command: string[], options?: BunSpawnTerminalOptions): BunSubprocess
+  }
+}

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -25,6 +25,7 @@ import {
 } from "./runtime-status.js"
 import {
   getActiveProcess,
+  setActiveProcess,
   spawnClaudeProcess,
   buildCliArgs,
   setClaudeSessionId,
@@ -35,6 +36,7 @@ import {
   isClaudeThinkingDisabled,
   sessionKey,
 } from "./session-manager.js"
+import { spawnInteractiveProcess } from "./claude-session-wrapper.js"
 import { log } from "./logger.js"
 import { detectCliVersion } from "./cli-version.js"
 import {
@@ -1655,6 +1657,17 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     const toUsage = this.toUsage.bind(this)
     const toFinishReason = this.toFinishReason.bind(this)
     const handleControlRequest = this.handleControlRequest.bind(this)
+    const flagOn = (v: string | undefined) =>
+      v !== undefined &&
+      !["", "0", "false", "no", "off"].includes(v.trim().toLowerCase())
+    // Interactive (subscription) transport: drive the claude TUI over Bun's
+    // native ConPTY + JSONL tail instead of headless `--print` stream-json.
+    // Self-healing: if Bun.Terminal is unavailable (e.g. not under Bun), fall
+    // back to the headless path. Default OFF -> existing behavior unchanged.
+    const useInteractive =
+      flagOn(process.env.CLAUDE_CODE_INTERACTIVE_TRANSPORT) &&
+      typeof (globalThis as any).Bun?.Terminal === "function"
+    const interactiveBypass = flagOn(process.env.CLAUDE_CODE_INTERACTIVE_BYPASS)
 
     if (scope === "no-tools" && !compactionMode) {
       log.info("doStream no-tools title stub", {
@@ -1827,6 +1840,43 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
         }
 
         const setup = async () => {
+          if (useInteractive && !compactionMode) {
+            // Interactive Bun-ConPTY transport. Reuse the live session if one
+            // exists for this key; else spawn a new interactive claude. The
+            // wrapper conforms to ActiveProcess, so reuse/eviction/hot-reload
+            // and the whole emission body below work unchanged.
+            const mcp = self.effectiveMcpConfig(cwd, undefined, runtimeStatus!)
+            if (activeProcess) {
+              proc = activeProcess.proc
+              lineEmitter = activeProcess.lineEmitter
+              log.debug("reusing active interactive session", { sk })
+            } else {
+              const allow = [
+                ...mcp.allEnabledServerNames.map((n) => `mcp__${n}__*`),
+                "mcp__opencode_proxy__*",
+                "Bash",
+                "Edit",
+                "Write",
+                "Read",
+                "WebFetch",
+              ]
+              const ap = spawnInteractiveProcess({
+                cwd,
+                model: effectiveModelId,
+                mcpConfigPaths: mcp.paths,
+                permissionsAllow: allow,
+                permissionMode: interactiveBypass
+                  ? "bypassPermissions"
+                  : undefined,
+              })
+              ap.mcpHash = mcp.bridgedHash
+              setActiveProcess(sk, ap)
+              proc = ap.proc
+              lineEmitter = ap.lineEmitter
+              activeProcess = ap
+              log.info("spawned interactive claude session", { sk })
+            }
+          } else {
           let cliArgs: string[]
           let spawnSystemPromptFile: string | undefined
           let spawnProxyServer: ProxyMcpServer | null = null
@@ -1929,6 +1979,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
             proc = ap.proc
             lineEmitter = ap.lineEmitter
             activeProcess = ap
+          }
           }
 
           controller.enqueue({ type: "stream-start", warnings })
@@ -2510,11 +2561,6 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                     string,
                     unknown
                   >
-                  toolCallsById.set(block.id, {
-                    id: block.id,
-                    name: block.name,
-                    input: parsedInput,
-                  })
 
                   if (isAskUserQuestionTool(block.name)) {
                     const askId = startTextBlock()
@@ -2552,6 +2598,11 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                     })
 
                     if (!skip) {
+                      toolCallsById.set(block.id, {
+                        id: block.id,
+                        name: block.name,
+                        input: parsedInput,
+                      })
                       if (!executed) skipResultForIds.add(block.id)
                       controller.enqueue({
                         type: "tool-input-start",

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -1662,12 +1662,17 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
       !["", "0", "false", "no", "off"].includes(v.trim().toLowerCase())
     // Interactive (subscription) transport: drive the claude TUI over Bun's
     // native ConPTY + JSONL tail instead of headless `--print` stream-json.
-    // Self-healing: if Bun.Terminal is unavailable (e.g. not under Bun), fall
-    // back to the headless path. Default OFF -> existing behavior unchanged.
+    // Prefer the provider option (config-driven, reliable in the GUI app where
+    // process env vars are not inherited); fall back to the env var. Self-healing:
+    // if Bun.Terminal is unavailable (e.g. not under Bun), use the headless path.
+    const interactivePref =
+      this.config.interactive ??
+      flagOn(process.env.CLAUDE_CODE_INTERACTIVE_TRANSPORT)
     const useInteractive =
-      flagOn(process.env.CLAUDE_CODE_INTERACTIVE_TRANSPORT) &&
-      typeof (globalThis as any).Bun?.Terminal === "function"
-    const interactiveBypass = flagOn(process.env.CLAUDE_CODE_INTERACTIVE_BYPASS)
+      interactivePref && typeof (globalThis as any).Bun?.Terminal === "function"
+    const interactiveBypass =
+      this.config.interactiveBypass ??
+      flagOn(process.env.CLAUDE_CODE_INTERACTIVE_BYPASS)
 
     if (scope === "no-tools" && !compactionMode) {
       log.info("doStream no-tools title stub", {

--- a/src/claude-session-bun.ts
+++ b/src/claude-session-bun.ts
@@ -288,6 +288,69 @@ export class ClaudeSession {
     }
   }
 
+  /**
+   * Like ask(), but instead of collecting the reply text it re-emits each NEW
+   * raw JSONL transcript line via onLine (verbatim) until a terminal
+   * stop_reason. Returns the terminal stop_reason + the last assistant usage.
+   * Used by the opencode plugin transport shim, which feeds these raw lines
+   * into the existing stream-json line handler unchanged.
+   */
+  async tailTurn(
+    prompt: string,
+    onLine: (rawLine: string) => void,
+    perTurnTimeoutMs?: number
+  ): Promise<{ stopReason: string | null; usage: any | null }> {
+    if (this.aborted) throw new Error('aborted')
+    if (!this.proc || this.exited)
+      throw new Error('session not started or already exited')
+    const timeout = perTurnTimeoutMs ?? this.o.turnTimeoutMs
+
+    if (this.o.bracketedPaste) {
+      this.proc.terminal.write('\x1b[200~' + prompt + '\x1b[201~')
+    } else {
+      this.proc.terminal.write(prompt)
+    }
+    await delay(200)
+    this.proc.terminal.write('\r')
+
+    let lastUsage: any = null
+    let stopReason: string | null = null
+    const deadline = Date.now() + timeout
+
+    while (Date.now() < deadline) {
+      await delay(this.o.pollMs)
+      if (this.aborted) throw new Error('aborted mid-turn')
+      if (this.exited) break
+      const lines = this.readRawLines()
+      const lastComplete = lines.length - 1
+      if (lastComplete <= this.cursor) continue
+      for (let i = this.cursor; i < lastComplete; i++) {
+        const s = lines[i]
+        if (!s || !s.trim()) continue
+        onLine(s)
+        let rec: any
+        try {
+          rec = JSON.parse(s)
+        } catch {
+          continue
+        }
+        if (rec.type === 'assistant' && rec.message) {
+          if (rec.message.usage) lastUsage = rec.message.usage
+          if (
+            rec.message.stop_reason &&
+            TERMINAL_STOP.has(rec.message.stop_reason)
+          ) {
+            stopReason = rec.message.stop_reason
+          }
+        }
+      }
+      this.cursor = lastComplete
+      if (stopReason) break
+    }
+
+    return { stopReason, usage: lastUsage }
+  }
+
   dispose(): void {
     if (this.proc) {
       try {

--- a/src/claude-session-bun.ts
+++ b/src/claude-session-bun.ts
@@ -314,6 +314,7 @@ export class ClaudeSession {
     this.proc.terminal.write('\r')
 
     let lastUsage: any = null
+    let totalOutput = 0
     let stopReason: string | null = null
     const deadline = Date.now() + timeout
 
@@ -335,7 +336,10 @@ export class ClaudeSession {
           continue
         }
         if (rec.type === 'assistant' && rec.message) {
-          if (rec.message.usage) lastUsage = rec.message.usage
+          if (rec.message.usage) {
+            lastUsage = rec.message.usage
+            totalOutput += rec.message.usage.output_tokens ?? 0
+          }
           if (
             rec.message.stop_reason &&
             TERMINAL_STOP.has(rec.message.stop_reason)
@@ -348,7 +352,23 @@ export class ClaudeSession {
       if (stopReason) break
     }
 
-    return { stopReason, usage: lastUsage }
+    // Context (input/cache) = the LAST record's full conversation state; output
+    // = SUM across all assistant records this turn (each generation), else
+    // multi-record tool turns undercount output. toUsage() prefers
+    // iterations[last], so patch that entry's output too.
+    let usage: any = lastUsage
+    if (lastUsage) {
+      usage = { ...lastUsage, output_tokens: totalOutput }
+      if (Array.isArray(lastUsage.iterations) && lastUsage.iterations.length > 0) {
+        const iters = lastUsage.iterations.map((it: any) => ({ ...it }))
+        iters[iters.length - 1] = {
+          ...iters[iters.length - 1],
+          output_tokens: totalOutput,
+        }
+        usage.iterations = iters
+      }
+    }
+    return { stopReason, usage }
   }
 
   dispose(): void {

--- a/src/claude-session-bun.ts
+++ b/src/claude-session-bun.ts
@@ -80,6 +80,16 @@ export interface ClaudeSessionOptions {
   /** false = plain write(prompt)+Enter; true = wrap in bracketed-paste so
    *  multi-line prompts don't submit early. Default true. */
   bracketedPaste?: boolean
+  /** Submitting a turn: a large/multi-line bracketed paste collapses into a
+   *  "[Pasted text]" placeholder, and an Enter sent while claude is still
+   *  ingesting the paste is silently DROPPED — so a single fixed-delay Enter is
+   *  unreliable and the turn can hang until turnTimeoutMs. Instead: wait
+   *  submitMinMs, send Enter, then confirm the turn was accepted (a new
+   *  transcript record appears) within submitConfirmMs; if not, resend Enter,
+   *  up to submitMaxRetries times. */
+  submitMinMs?: number
+  submitConfirmMs?: number
+  submitMaxRetries?: number
   /** Abort the call (during boot or an in-flight turn): kills the process and
    *  rejects with an "aborted" error. */
   signal?: AbortSignal
@@ -130,6 +140,9 @@ export class ClaudeSession {
       pollMs: opts.pollMs ?? 250,
       turnTimeoutMs: opts.turnTimeoutMs ?? 120000,
       bracketedPaste: opts.bracketedPaste ?? true,
+      submitMinMs: opts.submitMinMs ?? 200,
+      submitConfirmMs: opts.submitConfirmMs ?? 1500,
+      submitMaxRetries: opts.submitMaxRetries ?? 8,
       debug: opts.debug ?? false,
     }
   }
@@ -193,6 +206,29 @@ export class ClaudeSession {
     }
   }
 
+  /** Submit the freshly-injected prompt and confirm the turn was actually
+   *  accepted. A large bracketed paste collapses into a "[Pasted text]"
+   *  placeholder; an Enter sent while claude is still ingesting the paste is
+   *  silently dropped, so a single fixed-delay Enter races the paste and can
+   *  leave the prompt sitting unsubmitted (→ hang until turnTimeoutMs). Send
+   *  Enter, then poll for transcript growth past the cursor (the turn's records
+   *  are written on acceptance); resend Enter until accepted or the retry
+   *  budget is spent. Polling growth (not a blind delay) also stops us from
+   *  sending a stray Enter once the turn is in flight. */
+  private async submitTurn(): Promise<void> {
+    await delay(this.o.submitMinMs)
+    for (let attempt = 0; attempt < this.o.submitMaxRetries; attempt++) {
+      if (this.aborted || this.exited || !this.proc) return
+      this.proc.terminal.write("\r")
+      const until = Date.now() + this.o.submitConfirmMs
+      while (Date.now() < until) {
+        await delay(80)
+        if (this.aborted || this.exited) return
+        if (this.lineCount() > this.cursor) return // turn accepted
+      }
+    }
+  }
+
   private readRawLines(): string[] {
     try {
       return fs.readFileSync(this.jsonlPath, "utf8").split("\n")
@@ -218,14 +254,15 @@ export class ClaudeSession {
     const timeout = perTurnTimeoutMs ?? this.o.turnTimeoutMs
     const t0 = Date.now()
 
-    // Inject. Bracketed paste keeps multi-line prompts from submitting early.
+    // Inject. Bracketed paste keeps multi-line prompts from submitting early;
+    // submitTurn() then presses Enter and confirms the turn was accepted,
+    // resending Enter if the (collapsed) paste swallowed the first one.
     if (this.o.bracketedPaste) {
       this.proc.terminal.write("\x1b[200~" + prompt + "\x1b[201~")
     } else {
       this.proc.terminal.write(prompt)
     }
-    await delay(200)
-    this.proc.terminal.write("\r")
+    await this.submitTurn()
 
     const collected: string[] = []
     let lastUsage: any = null
@@ -314,8 +351,7 @@ export class ClaudeSession {
     } else {
       this.proc.terminal.write(prompt)
     }
-    await delay(200)
-    this.proc.terminal.write('\r')
+    await this.submitTurn()
 
     let lastUsage: any = null
     let totalOutput = 0

--- a/src/claude-session-bun.ts
+++ b/src/claude-session-bun.ts
@@ -1,0 +1,319 @@
+import * as os from "node:os"
+import * as fs from "node:fs"
+import * as path from "node:path"
+import { execFileSync } from "node:child_process"
+import { randomUUID } from "node:crypto"
+
+/**
+ * Persistent interactive Claude Code session driven over Bun's NATIVE PTY
+ * (Bun.spawn `terminal` option = openpty on POSIX, ConPTY on Windows). This is
+ * the in-process Bun port of claude-tui-bridge/src/claudeSession.ts: same
+ * design, node-pty swapped for Bun's own ConPTY so it runs inside opencode's
+ * Bun runtime with NO node sidecar and NO node-pty dependency.
+ *
+ *   - ONE long-lived interactive `claude` process per session (multi-turn),
+ *   - turns injected by writing into the terminal (bracketed paste + Enter),
+ *   - replies captured by tailing the session JSONL transcript
+ *     (~/.claude/projects/<encoded-cwd>/<session-id>.jsonl) and parsing the
+ *     assistant records; completion detected by a terminal `stop_reason`.
+ *
+ * Driving the INTERACTIVE TUI (real TTY) keeps model calls on the subscription
+ * billing path (not `claude -p` / Agent SDK, which meter after 2026-06-15).
+ */
+
+function resolveClaude(cmd = "claude"): string {
+  if (path.isAbsolute(cmd) && fs.existsSync(cmd)) return cmd
+  const viaBun = Bun.which(cmd)
+  if (viaBun) return viaBun
+  const isWin = os.platform() === "win32"
+  try {
+    const out = execFileSync(isWin ? "where" : "which", [cmd], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    const first = out
+      .split(/\r?\n/)
+      .map((l) => l.trim())
+      .filter(Boolean)
+      .find((p) => fs.existsSync(p))
+    if (first) return first
+  } catch {}
+  throw new Error(`Could not resolve command on PATH: ${cmd}`)
+}
+
+/** Claude encodes the absolute cwd into the transcript dir name by replacing
+ *  EVERY non-alphanumeric char with `-` (no collapsing of runs). Verified on
+ *  Windows against ~/.claude/projects, e.g.:
+ *    C:\code\my-app    -> C--code-my-app
+ *    C:\dev\My Project -> C--dev-My-Project   (the space also becomes `-`). */
+export function encodeCwd(cwd: string): string {
+  return path.resolve(cwd).replace(/[^a-zA-Z0-9]/g, "-")
+}
+
+export interface TurnResult {
+  text: string
+  stopReason: string | null
+  usage: any | null
+  cacheReadTokens: number
+  cacheCreationTokens: number
+  ephemeral1hTokens: number
+  ephemeral5mTokens: number
+  inputTokens: number
+  outputTokens: number
+  elapsedMs: number
+}
+
+export interface ClaudeSessionOptions {
+  cwd?: string
+  model?: string
+  /** '' bypasses CLAUDE.md + user/project/local settings load (fast tests).
+   *  null/undefined omits the flag entirely (normal settings). */
+  settingSources?: string | null
+  extraArgs?: string[]
+  cols?: number
+  rows?: number
+  bootMinMs?: number
+  bootQuietMs?: number
+  bootMaxMs?: number
+  pollMs?: number
+  turnTimeoutMs?: number
+  /** false = plain write(prompt)+Enter; true = wrap in bracketed-paste so
+   *  multi-line prompts don't submit early. Default true. */
+  bracketedPaste?: boolean
+  /** Abort the call (during boot or an in-flight turn): kills the process and
+   *  rejects with an "aborted" error. */
+  signal?: AbortSignal
+  debug?: boolean
+}
+
+const TERMINAL_STOP = new Set(["end_turn", "stop_sequence", "max_tokens"])
+const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+export class ClaudeSession {
+  readonly sessionId: string
+  readonly cwd: string
+  readonly jsonlPath: string
+  raw = ""
+
+  private proc: BunSubprocess | null = null
+  private cursor = 0 // index into transcript split('\n')
+  private lastDataAt = 0
+  private exited = false
+  private aborted = false
+  private readonly signal?: AbortSignal
+  private readonly o: Required<
+    Omit<ClaudeSessionOptions, "model" | "settingSources" | "extraArgs" | "signal">
+  > &
+    Pick<ClaudeSessionOptions, "model" | "settingSources" | "extraArgs">
+
+  constructor(opts: ClaudeSessionOptions = {}) {
+    this.cwd = path.resolve(opts.cwd ?? process.cwd())
+    this.signal = opts.signal
+    this.sessionId = randomUUID()
+    this.jsonlPath = path.join(
+      os.homedir(),
+      ".claude",
+      "projects",
+      encodeCwd(this.cwd),
+      `${this.sessionId}.jsonl`,
+    )
+    this.o = {
+      cwd: this.cwd,
+      model: opts.model,
+      settingSources: opts.settingSources,
+      extraArgs: opts.extraArgs ?? [],
+      cols: opts.cols ?? 200,
+      rows: opts.rows ?? 50,
+      bootMinMs: opts.bootMinMs ?? 3000,
+      bootQuietMs: opts.bootQuietMs ?? 1500,
+      bootMaxMs: opts.bootMaxMs ?? 25000,
+      pollMs: opts.pollMs ?? 250,
+      turnTimeoutMs: opts.turnTimeoutMs ?? 120000,
+      bracketedPaste: opts.bracketedPaste ?? true,
+      debug: opts.debug ?? false,
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this.signal?.aborted) throw new Error("aborted before start")
+    this.signal?.addEventListener(
+      "abort",
+      () => {
+        this.aborted = true
+        this.dispose()
+      },
+      { once: true },
+    )
+    const claude = resolveClaude()
+    const args: string[] = ["--session-id", this.sessionId]
+    if (this.o.model) args.push("--model", this.o.model)
+    if (this.o.settingSources !== null && this.o.settingSources !== undefined) {
+      args.push("--setting-sources", this.o.settingSources)
+    }
+    if (this.o.extraArgs && this.o.extraArgs.length) args.push(...this.o.extraArgs)
+
+    if (this.o.debug)
+      process.stderr.write(`[session] spawn: ${claude} ${args.join(" ")}\n`)
+
+    this.lastDataAt = Date.now()
+    this.proc = Bun.spawn([claude, ...args], {
+      cwd: this.cwd,
+      env: { ...process.env, TERM: "xterm-256color" },
+      terminal: {
+        cols: this.o.cols,
+        rows: this.o.rows,
+        data: (_term, d) => {
+          this.lastDataAt = Date.now()
+          const chunk = Buffer.from(d).toString("utf8")
+          this.raw += chunk
+          if (this.o.debug) process.stdout.write(chunk)
+        },
+      },
+    })
+    this.proc.exited.then(() => {
+      this.exited = true
+      this.proc = null
+    })
+
+    await this.waitForBoot()
+    this.cursor = this.lineCount()
+  }
+
+  /** Wait until the TUI has been quiet for bootQuietMs (Ink ready), bounded by
+   *  bootMinMs..bootMaxMs. */
+  private async waitForBoot(): Promise<void> {
+    const start = Date.now()
+    while (Date.now() - start < this.o.bootMaxMs) {
+      await delay(150)
+      if (this.aborted) throw new Error("aborted during boot")
+      if (this.exited) throw new Error("claude exited during boot")
+      const elapsed = Date.now() - start
+      const sinceData = Date.now() - this.lastDataAt
+      if (elapsed >= this.o.bootMinMs && sinceData >= this.o.bootQuietMs) return
+    }
+  }
+
+  private readRawLines(): string[] {
+    try {
+      return fs.readFileSync(this.jsonlPath, "utf8").split("\n")
+    } catch {
+      return []
+    }
+  }
+
+  /** Count of complete lines (split('\n') minus the trailing/partial element). */
+  private lineCount(): number {
+    const lines = this.readRawLines()
+    return lines.length > 0 ? lines.length - 1 : 0
+  }
+
+  /**
+   * Inject a turn into the live session and return the assistant reply once a
+   * terminal stop_reason is observed in the transcript.
+   */
+  async ask(prompt: string, perTurnTimeoutMs?: number): Promise<TurnResult> {
+    if (this.aborted) throw new Error("aborted")
+    if (!this.proc || this.exited)
+      throw new Error("session not started or already exited")
+    const timeout = perTurnTimeoutMs ?? this.o.turnTimeoutMs
+    const t0 = Date.now()
+
+    // Inject. Bracketed paste keeps multi-line prompts from submitting early.
+    if (this.o.bracketedPaste) {
+      this.proc.terminal.write("\x1b[200~" + prompt + "\x1b[201~")
+    } else {
+      this.proc.terminal.write(prompt)
+    }
+    await delay(200)
+    this.proc.terminal.write("\r")
+
+    const collected: string[] = []
+    let lastUsage: any = null
+    let stopReason: string | null = null
+    const deadline = Date.now() + timeout
+
+    while (Date.now() < deadline) {
+      await delay(this.o.pollMs)
+      if (this.aborted) throw new Error("aborted mid-turn")
+      if (this.exited) throw new Error("claude exited mid-turn")
+      const lines = this.readRawLines()
+      const lastComplete = lines.length - 1 // exclusive bound; trailing/partial line skipped
+      if (lastComplete <= this.cursor) continue
+
+      for (let i = this.cursor; i < lastComplete; i++) {
+        const s = lines[i]
+        if (!s || !s.trim()) continue
+        let rec: any
+        try {
+          rec = JSON.parse(s)
+        } catch {
+          continue
+        }
+        if (rec.type === "assistant" && rec.message) {
+          for (const b of rec.message.content ?? []) {
+            if (b?.type === "text" && typeof b.text === "string")
+              collected.push(b.text)
+          }
+          if (rec.message.usage) lastUsage = rec.message.usage
+          if (
+            rec.message.stop_reason &&
+            TERMINAL_STOP.has(rec.message.stop_reason)
+          ) {
+            stopReason = rec.message.stop_reason
+          }
+        }
+      }
+      this.cursor = lastComplete
+      if (stopReason) break
+    }
+
+    if (!stopReason) {
+      throw new Error(
+        `turn timed out after ${timeout}ms (no terminal assistant record; collected ${collected.length} text block(s))`,
+      )
+    }
+
+    const u = lastUsage ?? {}
+    return {
+      text: collected.join("\n").trim(),
+      stopReason,
+      usage: lastUsage,
+      cacheReadTokens: u.cache_read_input_tokens ?? 0,
+      cacheCreationTokens: u.cache_creation_input_tokens ?? 0,
+      ephemeral1hTokens: u.cache_creation?.ephemeral_1h_input_tokens ?? 0,
+      ephemeral5mTokens: u.cache_creation?.ephemeral_5m_input_tokens ?? 0,
+      inputTokens: u.input_tokens ?? 0,
+      outputTokens: u.output_tokens ?? 0,
+      elapsedMs: Date.now() - t0,
+    }
+  }
+
+  dispose(): void {
+    if (this.proc) {
+      try {
+        this.proc.terminal.write("\x03")
+      } catch {}
+      try {
+        this.proc.kill()
+      } catch {}
+      try {
+        this.proc.terminal.close()
+      } catch {}
+    }
+    this.proc = null
+  }
+}
+
+/** One-shot convenience (drop-in for `claude -p`): start, ask, dispose. */
+export async function askOnce(
+  prompt: string,
+  opts: ClaudeSessionOptions = {},
+): Promise<TurnResult> {
+  const s = new ClaudeSession(opts)
+  await s.start()
+  try {
+    return await s.ask(prompt)
+  } finally {
+    s.dispose()
+  }
+}

--- a/src/claude-session-bun.ts
+++ b/src/claude-session-bun.ts
@@ -235,10 +235,14 @@ export class ClaudeSession {
     while (Date.now() < deadline) {
       await delay(this.o.pollMs)
       if (this.aborted) throw new Error("aborted mid-turn")
-      if (this.exited) throw new Error("claude exited mid-turn")
       const lines = this.readRawLines()
       const lastComplete = lines.length - 1 // exclusive bound; trailing/partial line skipped
-      if (lastComplete <= this.cursor) continue
+      if (lastComplete <= this.cursor) {
+        // Drain the transcript before reacting to exit: a final assistant record
+        // can be flushed in the same tick the process exits.
+        if (this.exited) throw new Error("claude exited mid-turn")
+        continue
+      }
 
       for (let i = this.cursor; i < lastComplete; i++) {
         const s = lines[i]
@@ -321,10 +325,14 @@ export class ClaudeSession {
     while (Date.now() < deadline) {
       await delay(this.o.pollMs)
       if (this.aborted) throw new Error('aborted mid-turn')
-      if (this.exited) break
       const lines = this.readRawLines()
       const lastComplete = lines.length - 1
-      if (lastComplete <= this.cursor) continue
+      if (lastComplete <= this.cursor) {
+        // Drain the transcript before reacting to exit: the terminal assistant
+        // record can land in the same tick the process exits.
+        if (this.exited) break
+        continue
+      }
       for (let i = this.cursor; i < lastComplete; i++) {
         const s = lines[i]
         if (!s || !s.trim()) continue

--- a/src/claude-session-wrapper.ts
+++ b/src/claude-session-wrapper.ts
@@ -1,0 +1,150 @@
+import { EventEmitter } from "node:events"
+import { ClaudeSession } from "./claude-session-bun.js"
+import type { ActiveProcess } from "./session-manager.js"
+import { log } from "./logger.js"
+
+export interface InteractiveSpawnOptions {
+  cwd: string
+  model?: string
+  /** Bridged Claude `--mcp-config` file paths (from effectiveMcpConfig). */
+  mcpConfigPaths?: string[]
+  /** permissions.allow rules (e.g. mcp__server__*, Bash, Edit). */
+  permissionsAllow?: string[]
+  /** "default" | "bypassPermissions" (the latter dodges the folder-trust gate). */
+  permissionMode?: string
+  /** "" = skip CLAUDE.md + ambient settings (default); null = normal settings. */
+  settingSources?: string | null
+}
+
+/**
+ * Adapt a ClaudeSession (interactive Bun ConPTY transport) to the ActiveProcess
+ * contract the doStream line handler depends on. The shim's `proc.stdin.write`
+ * injects a turn into the live interactive `claude` and re-emits each new JSONL
+ * transcript record on `lineEmitter` as a 'line' event, plus a synthetic
+ * `{type:'result'}` line on a terminal stop_reason so the existing finish branch
+ * (usage + providerMetadata + controller.close) fires unchanged.
+ *
+ * No node-pty, no node sidecar: runs in-process under opencode's Bun (which
+ * bundles a Bun version with native ConPTY). Interactive = subscription billing.
+ */
+export function spawnInteractiveProcess(
+  opts: InteractiveSpawnOptions,
+): ActiveProcess {
+  const extraArgs: string[] = []
+  if (opts.mcpConfigPaths && opts.mcpConfigPaths.length > 0) {
+    extraArgs.push(
+      "--mcp-config",
+      ...opts.mcpConfigPaths,
+      "--strict-mcp-config",
+    )
+  }
+  if (opts.permissionsAllow && opts.permissionsAllow.length > 0) {
+    extraArgs.push(
+      "--settings",
+      JSON.stringify({ permissions: { allow: opts.permissionsAllow } }),
+    )
+  }
+  if (opts.permissionMode) {
+    extraArgs.push("--permission-mode", opts.permissionMode)
+  }
+
+  const session = new ClaudeSession({
+    cwd: opts.cwd,
+    model: opts.model,
+    settingSources:
+      opts.settingSources === undefined ? "" : opts.settingSources,
+    extraArgs,
+  })
+
+  const lineEmitter = new EventEmitter()
+  const errorHandlers = new Set<(err: Error) => void>()
+  let startPromise: Promise<void> | null = null
+
+  const ensureStarted = (): Promise<void> => {
+    if (!startPromise) startPromise = session.start()
+    return startPromise
+  }
+
+  const runTurn = (userMsg: string): void => {
+    void (async () => {
+      try {
+        await ensureStarted()
+        const { stopReason, usage } = await session.tailTurn(userMsg, (raw) => {
+          lineEmitter.emit("line", raw)
+        })
+        // Synthesize the `result` line the headless transport would have
+        // emitted, so doStream's existing finish branch runs verbatim.
+        lineEmitter.emit(
+          "line",
+          JSON.stringify({
+            type: "result",
+            subtype: stopReason ?? "end_turn",
+            is_error: false,
+            session_id: session.sessionId,
+            usage: usage ?? {},
+            total_cost_usd: null,
+            duration_ms: 0,
+          }),
+        )
+        if (!stopReason) {
+          // No terminal stop (timeout / process gone): graceful close so
+          // doStream emits finish(stop) instead of hanging.
+          lineEmitter.emit("close")
+        }
+      } catch (err) {
+        const e = err instanceof Error ? err : new Error(String(err))
+        log.error("interactive turn failed", { error: e.message })
+        if (errorHandlers.size > 0) {
+          for (const h of errorHandlers) h(e)
+        } else {
+          lineEmitter.emit("close")
+        }
+      }
+    })()
+  }
+
+  // Minimal ChildProcess-shaped shim: only the members doStream/session-manager
+  // actually touch (stdin.write, on/off 'error', kill).
+  const proc: any = {
+    stdin: {
+      write(chunk: string): boolean {
+        const userMsg =
+          typeof chunk === "string" && chunk.endsWith("\n")
+            ? chunk.slice(0, -1)
+            : chunk
+        runTurn(userMsg)
+        return true
+      },
+      end(): void {},
+    },
+    stdout: null,
+    stderr: null,
+    pid: -1,
+    killed: false,
+    on(event: string, fn: (err: Error) => void): unknown {
+      if (event === "error") errorHandlers.add(fn)
+      return proc
+    },
+    once(): unknown {
+      return proc
+    },
+    off(event: string, fn: (err: Error) => void): unknown {
+      if (event === "error") errorHandlers.delete(fn)
+      return proc
+    },
+    kill(): boolean {
+      try {
+        session.dispose()
+      } catch {}
+      proc.killed = true
+      return true
+    },
+  }
+
+  return {
+    proc: proc as unknown as ActiveProcess["proc"],
+    lineEmitter,
+    proxyServer: null,
+    mcpHash: undefined,
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,8 @@ export function createClaudeCode(
       autoContinueIncompleteTurns:
         settings.autoContinueIncompleteTurns ?? "smart",
       compactionModel: settings.compactionModel,
+      interactive: settings.interactive,
+      interactiveBypass: settings.interactiveBypass,
     })
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,10 @@ export type { LogLevel, LogMode }
 export interface ClaudeCodeConfig {
   provider: string
   cliPath: string
+  /** Drive interactive claude (subscription) instead of headless --print. */
+  interactive?: boolean
+  /** With interactive: use --permission-mode bypassPermissions (folder-trust). */
+  interactiveBypass?: boolean
   cwd?: string
   account?: string
   configDir?: string
@@ -60,6 +64,10 @@ export type WebSearchRouting = "claude" | "disabled" | (string & {})
 
 export interface ClaudeCodeProviderSettings {
   cliPath?: string
+  /** Drive interactive claude (subscription) instead of headless --print. */
+  interactive?: boolean
+  /** With interactive: use --permission-mode bypassPermissions (folder-trust). */
+  interactiveBypass?: boolean
   cwd?: string
   name?: string
   providerID?: string


### PR DESCRIPTION
Drives the interactive claude TUI over Bun native ConPTY + JSONL-tail instead of headless `claude --print` stream-json, so model calls stay on the subscription path (not the metered Agent SDK pool after 06-15). Opt-in via `provider.claude-code.options.interactive` (env `CLAUDE_CODE_INTERACTIVE_TRANSPORT` fallback); headless stays the default, so it is a no-op unless enabled. Refs #9.