### PR TITLE
fix: remove stopReason short-circuit from auto-continue

### DIFF
--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -431,18 +431,13 @@ export function shouldAutoContinueIncompleteTurn(
   // continue — it is waiting for a reply, not stalled. Latched so it holds
   // even when the trailing text after the question doesn't read as a question.
   if (state.sawAskUserQuestion) return { continue: false, reason: "question" }
-  // v0.4.17: trust ANY protocol-level stop_reason as authoritative. If
-  // Claude CLI emitted a stop_reason value at all, the model has signaled
-  // a stop — honor it without consulting the keyword heuristic. The
-  // heuristic only runs as a fallback when stop_reason is missing (older
-  // CLI versions / edge cases). Maps snake_case → kebab-case for reason
-  // label consistency with other reasons.
-  if (snapshot.stopReason) {
-    return {
-      continue: false,
-      reason: snapshot.stopReason.replace(/_/g, "-"),
-    }
-  }
+  // NOTE: v0.4.17 removed the `stopReason` guard here. The protocol-level
+  // stop_reason (e.g. "end_turn") fires even when the model generated tool
+  // calls in the same turn — blocking auto-continue prematurely. The
+  // `hadActivity` check below already covers the "model did nothing" case:
+  // if there was no reasoning, no tool activity, and no proxy activity we
+  // return false. Keeping stopReason would make the heuristic unreachable
+  // for the common "text + tool_calls" pattern.
   if (state.attempts >= AUTO_CONTINUE_MAX_ATTEMPTS) {
     return { continue: false, reason: "max-attempts" }
   }
@@ -2892,8 +2887,32 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
                     count: drainBuffer.length,
                   },
                 )
-                drainNow()
-                return
+                // Enqueue tool-call events into the stream so opencode
+                // executes them, but do NOT close the controller yet.
+                // finishWithToolCalls() would close it, preventing
+                // auto-continue from firing on this turn.  Instead,
+                // enqueue the tool-call events manually, then fall
+                // through to the auto-continue check below.
+                if (!controllerClosed) {
+                  const batch = drainBuffer.splice(0, drainBuffer.length)
+                  for (const call of batch) {
+                    controller.enqueue({
+                      type: "tool-input-start",
+                      id: call.toolCallId,
+                      toolName: call.toolName,
+                    } as any)
+                    controller.enqueue({
+                      type: "tool-call",
+                      toolCallId: call.toolCallId,
+                      toolName: call.toolName,
+                      input: JSON.stringify(call.input),
+                      providerExecuted: false,
+                    } as any)
+                    skipResultForIds.add(call.toolCallId)
+                  }
+                  // Do NOT send finish or close controller here —
+                  // let the auto-continue check below decide.
+                }
               }
               const orphanPending = getPendingProxyCalls(sk)
               if (orphanPending.length > 0) {

--- a/test-auto-continue.ts
+++ b/test-auto-continue.ts
@@ -467,9 +467,9 @@ test("v0.4.15 'tests pass' (present tense) stops as final-answer", () => {
 
 test("v0.4.16 end_turn stop_reason short-circuits heuristic", () => {
   // Even a long ambiguous mid-task narration with no completion keywords
-  // and visible tool activity gets stopped immediately when Claude CLI
-  // signals end_turn. This is the architectural alternative to chasing
-  // soft-proceed idioms via regex (v0.4.10-15).
+  // v0.5.0: stopReason check removed. end_turn with tool activity now
+  // continues — the model was actively working when the turn ended.
+  // The hadActivity check below already covers the "model did nothing" case.
   const ambiguous =
     "Running the next probe to inspect the build output and confirm bundle sizes are roughly equal."
   const result = shouldAutoContinueIncompleteTurn(
@@ -481,17 +481,16 @@ test("v0.4.16 end_turn stop_reason short-circuits heuristic", () => {
       stopReason: "end_turn",
     }),
   )
-  assert.deepEqual(result, { continue: false, reason: "end-turn" })
+  assert.deepEqual(result, { continue: true, reason: "non-final-progress" })
 })
 
 test("v0.4.16 end_turn beats max-attempts (decided last)", () => {
-  // End-turn wins over budget guards too — once the model says it's done,
-  // there's no value in burning more attempts.
+  // v0.5.0: stopReason removed. Without activity, max-attempts wins.
   const result = shouldAutoContinueIncompleteTurn(
     state({ attempts: 999 }),
     snap({ stopReason: "end_turn", hadReasoning: true }),
   )
-  assert.deepEqual(result, { continue: false, reason: "end-turn" })
+  assert.deepEqual(result, { continue: false, reason: "max-attempts" })
 })
 
 test("v0.4.16 end_turn does NOT beat genuine error", () => {
@@ -513,8 +512,7 @@ test("v0.4.16 end_turn does NOT beat abort", () => {
 })
 
 test("v0.4.17 max_tokens stop_reason stops via protocol signal", () => {
-  // v0.4.17: ANY stop_reason value is authoritative. max_tokens is the
-  // model signaling a stop (it was cut off but the protocol said stop).
+  // v0.5.0: stopReason removed. max_tokens with tool activity now continues.
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({
@@ -524,53 +522,55 @@ test("v0.4.17 max_tokens stop_reason stops via protocol signal", () => {
       stopReason: "max_tokens",
     }),
   )
-  assert.deepEqual(result, { continue: false, reason: "max-tokens" })
+  assert.deepEqual(result, { continue: true, reason: "non-final-progress" })
 })
 
 test("v0.4.17 stop_sequence stops via protocol signal", () => {
+  // v0.5.0: stopReason removed. stop_sequence with reasoning now continues.
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({ stopReason: "stop_sequence", hadReasoning: true }),
   )
-  assert.deepEqual(result, { continue: false, reason: "stop-sequence" })
+  assert.deepEqual(result, { continue: true, reason: "activity-without-visible-answer" })
 })
 
 test("v0.4.17 refusal stops via protocol signal", () => {
+  // v0.5.0: stopReason removed. refusal with no activity stops at no-activity.
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({ stopReason: "refusal" }),
   )
-  assert.deepEqual(result, { continue: false, reason: "refusal" })
+  assert.deepEqual(result, { continue: false, reason: "no-activity" })
 })
 
 test("v0.4.17 pause_turn stops via protocol signal", () => {
+  // v0.5.0: stopReason removed. pause_turn with reasoning now continues.
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({ stopReason: "pause_turn", hadReasoning: true }),
   )
-  assert.deepEqual(result, { continue: false, reason: "pause-turn" })
+  assert.deepEqual(result, { continue: true, reason: "activity-without-visible-answer" })
 })
 
 test("v0.4.17 tool_use stops via protocol signal", () => {
-  // Defensive: tool_use shouldn't normally reach the result boundary
-  // (drain timer closes the stream first), but if it does we honor it.
+  // v0.5.0: stopReason removed. tool_use with tool activity now continues.
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({ stopReason: "tool_use", hadToolActivity: true }),
   )
-  assert.deepEqual(result, { continue: false, reason: "tool-use" })
+  assert.deepEqual(result, { continue: true, reason: "activity-without-visible-answer" })
 })
 
 test("v0.4.17 unknown stop_reason still stops (forward-compat)", () => {
-  // If Anthropic adds a new stop_reason value, we trust it as authoritative
-  // and stop. Safer than running the keyword heuristic on unknown shape.
+  // v0.5.0: stopReason removed. Unknown stop_reason with no activity stops
+  // at no-activity check (safer than trusting an unknown protocol value).
   const result = shouldAutoContinueIncompleteTurn(
     state(),
     snap({ stopReason: "future_value_we_dont_know" }),
   )
   assert.deepEqual(result, {
     continue: false,
-    reason: "future-value-we-dont-know",
+    reason: "no-activity",
   })
 })
 


### PR DESCRIPTION
## Problem

The `stopReason` guard in `shouldAutoContinueIncompleteTurn` (added in v0.4.17) blocked auto-continue whenever Claude CLI emitted ANY protocol-level `stop_reason` — even when the model was actively generating tool calls in the same turn.

This caused the common **"text + tool_calls"** pattern to terminate prematurely:

1. User sends a complex task
2. Claude generates intermediate text ("I'll analyse...") **+** tool calls (task/sub-agents)
3. Plugin sees `stop_reason: end_turn` → **blocks auto-continue immediately**
4. Turn closes before tool calls can execute
5. User sees partial response, has to manually send "Continua então."

## Root Cause

The `stopReason` check at line 440 ran **before** the `hadActivity` check at line 466. When `stop_reason` was present (which it always is in modern Claude CLI), auto-continue was short-circuited regardless of whether the model was actively working.

The `hadActivity\ check already covers the "model did nothing" case — if there was no reasoning, tool activity, or proxy activity, auto-continue stops correctly. The `stopReason` guard was redundant and counterproductive.

## Fix

1. **Removed the `stopReason` guard** from `shouldAutoContinueIncompleteTurn`. The `hadActivity` check at line 466 already handles the "model did nothing" case correctly.

2. **Restructured the drain path** at the result boundary: instead of calling `drainNow()` (which closes the controller via `finishWithToolCalls`), we now inline the tool-call enqueue and fall through to the auto-continue check. This prevents the controller from being closed before auto-continue gets a chance to fire.

## Test Changes

Updated 8 tests in `test-auto-continue.ts` to reflect the new behaviour:

- `end_turn` + tool activity → now **continues** (was: stopped)
- `max_tokens` + tool activity → now **continues** (was: stopped)
- `stop_sequence` + reasoning → now **continues** (was: stopped)
- `pause_turn` + reasoning → now **continues** (was: stopped)
- `tool_use` + tool activity → now **continues** (was: stopped)
- `refusal` + no activity → still **stops** (via `no-activity`)
- Unknown `stop_reason` + no activity → still **stops** (via `no-activity`)
- `end_turn` + max-attempts → still **stops** (via `max-attempts`)

All 203 tests pass.

## Impact

This fixes the premature turn termination users experience with Claude Opus 4.7 when generating sub-agent task calls. The model no longer needs manual "Continua então." prompts to keep working after generating tool calls.