### PR TITLE
Add configurable idle timeout for Claude workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,8 @@ The account model IDs are internally suffixed, for example `claude-sonnet-4-6@wo
         "skipPermissions": true,
         "permissionMode": "default",
         "bridgeOpencodeMcp": true,
-        "strictMcpConfig": false
+        "strictMcpConfig": false,
+        "idleProcessTimeoutMs": 900000
       }
     }
   }
@@ -191,6 +192,7 @@ The account model IDs are internally suffixed, for example `claude-sonnet-4-6@wo
 | `autoContinueIncompleteTurns` | boolean \| `"smart"` | `"smart"` | Smartly continue incomplete Claude CLI results inside the same opencode turn. Reduces manual "continue" presses when Claude ends after reasoning/tool activity without a useful final answer. Set `false` to disable. |
 | `compactionModel` | string | `"claude-haiku-4-5"` | Model used when opencode invokes `/compact`. Override per-process via the `CLAUDE_CODE_COMPACTION_MODEL` env var (env wins over config). See [Compaction](#compaction). |
 | `ignoreAnthropicApiKey` | boolean | `false` | Strip `ANTHROPIC_API_KEY` / `ANTHROPIC_AUTH_TOKEN` from every spawned `claude` process so it authenticates with your logged-in subscription instead of pay-as-you-go API billing. The plugin warns once at startup whenever an API key is detected, regardless of this setting. See [Billing](#billing-change-june-15-2026-agent-sdk-credit). |
+| `idleProcessTimeoutMs` | number | – | Kill a retained headless Claude worker after this many idle milliseconds following a completed turn. The session id is preserved for `--resume`; a new turn cancels the timer. Values above Node's maximum timer delay (`2147483647`) are ignored. Omit or set to `0` to retain workers until LRU eviction. Interactive transport is excluded. |
 | `interactive` | boolean | `false` | **Experimental.** Drive the interactive `claude` TUI (subscription billing) instead of headless `--print`. Requires opencode running under Bun with PTY support; silently falls back to headless otherwise. Env: `CLAUDE_CODE_INTERACTIVE_TRANSPORT=1`. See [Interactive transport](#interactive-transport-experimental). |
 | `interactiveBypass` | boolean | `false` | Deprecated/no-op with `interactive`: Claude Code's TUI shows a manual safety confirmation for `bypassPermissions`, so the plugin intentionally does not pass it. |
 | `interactiveAllowTools` | string[] | `["Bash", "Edit", "Write", "Read", "WebFetch"]` | With `interactive`: built-in tools pre-allowed without prompting (replaces the default list). MCP server wildcards (`mcp__<server>__*`) are always added from the bridged config. |
@@ -357,6 +359,7 @@ Each chat keeps a long-lived `claude` subprocess so the model retains its native
 - **New chat** → fresh process under the new session key.
 - **Resumed chat after restart** → in-memory state is gone; a new process spawns and the conversation history is summarized and prepended.
 - **Abort (Ctrl+C)** → stream closes, process stays alive for the next message in that chat.
+- **Idle timeout** → when `idleProcessTimeoutMs` is configured, a completed headless turn arms an eviction timer; reuse cancels it, and eviction preserves the session id for `--resume`.
 - **Cap**: 16 active processes, LRU eviction.
 
 ---

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "tsup",
     "dev": "tsup --watch",
     "typecheck": "tsc --noEmit",
-    "test": "tsx --test test-bridge.ts test-broker.ts test-auto-continue.ts test-has-new-user-content.ts test-get-claude-user-message.ts test-logger.ts test-cli-args.ts test-compaction-model.ts test-tool-mapping.ts test-cwd-resolution.ts test-todo-ledger.ts test-session-affinity.ts test-config-models.ts test-ask-user-question.ts test-claude-session-wrapper.ts test-spawn-env.ts"
+    "test": "tsx --test test-bridge.ts test-broker.ts test-auto-continue.ts test-has-new-user-content.ts test-get-claude-user-message.ts test-logger.ts test-cli-args.ts test-compaction-model.ts test-tool-mapping.ts test-cwd-resolution.ts test-todo-ledger.ts test-session-affinity.ts test-session-manager.ts test-config-models.ts test-ask-user-question.ts test-claude-session-wrapper.ts test-spawn-env.ts"
   },
   "dependencies": {
     "@ai-sdk/provider": "^3.0.8",

--- a/src/claude-code-language-model.ts
+++ b/src/claude-code-language-model.ts
@@ -32,6 +32,7 @@ import {
   getClaudeSessionId,
   deleteClaudeSessionId,
   deleteActiveProcess,
+  scheduleIdleProcessEviction,
   claudeSpawnEnv,
   isClaudeThinkingDisabled,
   sessionKey,
@@ -1308,7 +1309,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
     const cliArgs = buildCliArgs({
       sessionKey: sk,
       skipPermissions: this.config.skipPermissions !== false,
-      includeSessionId: false,
+      includeSessionResume: false,
       model: this.modelId,
       permissionMode: this.config.permissionMode,
       mcpConfig: this.effectiveMcpConfig(cwd, undefined, runtimeStatus).paths,
@@ -1841,7 +1842,7 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
         // config has drifted since spawn. Only checked between turns (here,
         // before setup() runs), never mid tool-call. The stored claude
         // session id is preserved so the respawn resumes the conversation
-        // via `--session-id` (handled by buildCliArgs).
+        // via `--resume` (handled by buildCliArgs).
         if (
           !compactionMode &&
           activeProcess &&
@@ -1942,12 +1943,12 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
             // appended system prompt, no disallowed-tools list. The model
             // is asked for text output only on a single turn — all the
             // normal tool wiring is pure overhead and adds latency.
-            // Explicitly opt out of `--session-id` so a stale id can never
+            // Explicitly opt out of `--resume` so a stale id can never
             // resume into the lean spawn.
             cliArgs = buildCliArgs({
               sessionKey: sk,
               skipPermissions,
-              includeSessionId: false,
+              includeSessionResume: false,
               model: effectiveModelId,
               permissionMode: self.config.permissionMode,
               cliVersion,
@@ -2999,6 +3000,12 @@ export class ClaudeCodeLanguageModel implements LanguageModelV3 {
 
               controllerClosed = true
               cleanupTurn()
+              if (!useInteractive && !compactionMode) {
+                scheduleIdleProcessEviction(
+                  sk,
+                  self.config.idleProcessTimeoutMs,
+                )
+              }
 
               try {
                 controller.close()

--- a/src/index.ts
+++ b/src/index.ts
@@ -99,6 +99,7 @@ export function createClaudeCode(
         settings.autoContinueIncompleteTurns ?? "smart",
       compactionModel: settings.compactionModel,
       ignoreAnthropicApiKey: settings.ignoreAnthropicApiKey,
+      idleProcessTimeoutMs: settings.idleProcessTimeoutMs,
       interactive: settings.interactive,
       interactiveBypass: settings.interactiveBypass,
       interactiveAllowTools: settings.interactiveAllowTools,

--- a/src/session-manager.ts
+++ b/src/session-manager.ts
@@ -32,6 +32,8 @@ export interface ActiveProcess {
 // make this a poor-man's LRU; see `touch()` below.
 const activeProcesses = new Map<string, ActiveProcess>()
 const claudeSessions = new Map<string, string>()
+const idleEvictionTimers = new Map<string, ReturnType<typeof setTimeout>>()
+const MAX_IDLE_TIMEOUT_MS = 2_147_483_647
 
 // Cap on live CLI subprocesses. Session-affinity-keyed entries accumulate
 // one-per-chat, so an unbounded map would leak processes as users open new
@@ -89,6 +91,13 @@ function touch(key: string): void {
   }
 }
 
+function cancelIdleProcessEviction(key: string): void {
+  const timer = idleEvictionTimers.get(key)
+  if (!timer) return
+  clearTimeout(timer)
+  idleEvictionTimers.delete(key)
+}
+
 function evictIfNeeded(): void {
   while (activeProcesses.size >= MAX_ACTIVE_PROCESSES) {
     const oldestKey = activeProcesses.keys().next().value
@@ -100,15 +109,53 @@ function evictIfNeeded(): void {
 
 export function getActiveProcess(key: string): ActiveProcess | undefined {
   const ap = activeProcesses.get(key)
-  if (ap) touch(key)
+  if (ap) {
+    cancelIdleProcessEviction(key)
+    touch(key)
+  }
   return ap
 }
 
 export function setActiveProcess(key: string, ap: ActiveProcess): void {
+  cancelIdleProcessEviction(key)
   activeProcesses.set(key, ap)
 }
 
+/**
+ * Evict a headless Claude worker after a completed turn has stayed idle.
+ * Reusing the worker through `getActiveProcess` cancels the timer. The
+ * Claude session id is intentionally retained so the next turn can continue
+ * the same conversation via `--resume`.
+ */
+export function scheduleIdleProcessEviction(
+  key: string,
+  timeoutMs: number | undefined,
+): void {
+  cancelIdleProcessEviction(key)
+  if (
+    typeof timeoutMs !== "number" ||
+    !Number.isFinite(timeoutMs) ||
+    timeoutMs <= 0 ||
+    timeoutMs > MAX_IDLE_TIMEOUT_MS
+  ) {
+    return
+  }
+
+  const scheduledProcess = activeProcesses.get(key)
+  if (!scheduledProcess) return
+
+  const timer = setTimeout(() => {
+    idleEvictionTimers.delete(key)
+    if (activeProcesses.get(key) !== scheduledProcess) return
+    log.info("evicting idle claude process", { sessionKey: key, timeoutMs })
+    deleteActiveProcess(key)
+  }, timeoutMs)
+  timer.unref()
+  idleEvictionTimers.set(key, timer)
+}
+
 export function deleteActiveProcess(key: string): void {
+  cancelIdleProcessEviction(key)
   const ap = activeProcesses.get(key)
   if (ap) {
     void ap.proxyServer?.close()
@@ -168,6 +215,7 @@ export function spawnClaudeProcess(
     mcpHash,
     systemPromptFile,
   }
+  cancelIdleProcessEviction(sessionKey)
   activeProcesses.set(sessionKey, ap)
 
   // Baseline 'error' listener so Node doesn't throw when the process emits
@@ -182,8 +230,12 @@ export function spawnClaudeProcess(
     if (systemPromptFile) {
       void unlink(systemPromptFile).catch(() => {})
     }
-    activeProcesses.delete(sessionKey)
-    if (code !== 0 && code !== null) {
+    const ownsSession = activeProcesses.get(sessionKey) === ap
+    if (ownsSession) {
+      cancelIdleProcessEviction(sessionKey)
+      activeProcesses.delete(sessionKey)
+    }
+    if (ownsSession && code !== 0 && code !== null) {
       log.info("process exited with error, clearing session", {
         code,
         sessionKey,
@@ -197,6 +249,7 @@ export function spawnClaudeProcess(
     log.debug("stderr", { data: stderr.slice(0, 200) })
 
     if (
+      activeProcesses.get(sessionKey) === ap &&
       stderr.includes("Session ID") &&
       (stderr.includes("already in use") ||
         stderr.includes("not found") ||
@@ -216,7 +269,7 @@ export function spawnClaudeProcess(
 export function buildCliArgs(opts: {
   sessionKey: string
   skipPermissions: boolean
-  includeSessionId?: boolean
+  includeSessionResume?: boolean
   model?: string
   permissionMode?: string
   mcpConfig?: string | string[]
@@ -230,7 +283,7 @@ export function buildCliArgs(opts: {
   const {
     sessionKey,
     skipPermissions,
-    includeSessionId = true,
+    includeSessionResume = true,
     model,
     permissionMode,
     mcpConfig,
@@ -259,10 +312,10 @@ export function buildCliArgs(opts: {
     args.push("--permission-mode", permissionMode)
   }
 
-  if (includeSessionId) {
+  if (includeSessionResume) {
     const sessionId = claudeSessions.get(sessionKey)
     if (sessionId && !activeProcesses.has(sessionKey)) {
-      args.push("--session-id", sessionId)
+      args.push("--resume", sessionId)
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,8 @@ export interface ClaudeCodeConfig {
   autoContinueIncompleteTurns?: boolean | "smart"
   compactionModel?: string
   ignoreAnthropicApiKey?: boolean
+  /** Kill an idle headless Claude worker after this many milliseconds. */
+  idleProcessTimeoutMs?: number
   logging?: LoggingConfig
 }
 
@@ -155,6 +157,15 @@ export interface ClaudeCodeProviderSettings {
   ignoreAnthropicApiKey?: boolean
 
   /**
+   * Kill a retained headless Claude worker after this many milliseconds of
+   * inactivity following a completed turn. Starting another turn cancels the
+   * timer, and the Claude session id is retained for a transparent resume.
+   * Omit or set to 0 to keep workers until LRU eviction. Interactive transport
+   * is excluded because it does not currently guarantee session-id resume.
+   */
+  idleProcessTimeoutMs?: number
+
+  /**
    * Routing for Claude's built-in `WebSearch` tool.
    *
    * - `"claude"` (default): Claude CLI runs WebSearch internally via
@@ -172,7 +183,7 @@ export interface ClaudeCodeProviderSettings {
    * underlying claude process so newly enabled / disabled MCPs become
    * visible to the model without restarting opencode or starting a new
    * chat. Eviction happens at the start of the next user turn (never mid
-   * tool-call) and `--session-id` is preserved so the conversation
+   * tool-call) and the session id is preserved for `--resume` so the conversation
    * continues seamlessly. Defaults to `true`.
    *
    * Set to `false` to keep the previous behavior (cached subprocess

--- a/test-config-models.ts
+++ b/test-config-models.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
-import { configModelsForProvider } from "./src/index.js"
+import { configModelsForProvider, createClaudeCode } from "./src/index.js"
 import { defaultModels } from "./src/models.js"
 import type { OpenCodeProvider } from "./src/opencode-types.js"
 
@@ -100,4 +100,12 @@ test("configModelsForProvider passes through user models not in defaults", () =>
 
   const models = configModelsForProvider(userConfig, "claude-code")
   assert.ok(models["my-custom-model"], "user-only model must be emitted")
+})
+
+test("createClaudeCode passes idle process timeout to language models", () => {
+  const model = createClaudeCode({ idleProcessTimeoutMs: 900_000 })(
+    "claude-sonnet-5",
+  )
+
+  assert.equal((model as any).config.idleProcessTimeoutMs, 900_000)
 })

--- a/test-session-manager.ts
+++ b/test-session-manager.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict"
+import { setTimeout as delay } from "node:timers/promises"
+import { EventEmitter } from "node:events"
+import { test } from "node:test"
+import {
+  deleteActiveProcess,
+  deleteClaudeSessionId,
+  buildCliArgs,
+  getActiveProcess,
+  scheduleIdleProcessEviction,
+  setClaudeSessionId,
+  setActiveProcess,
+  type ActiveProcess,
+} from "./src/session-manager.js"
+
+function fakeProcess(onKill: () => void): ActiveProcess {
+  return {
+    proc: {
+      kill() {
+        onKill()
+        return true
+      },
+    } as ActiveProcess["proc"],
+    lineEmitter: new EventEmitter(),
+  }
+}
+
+test("idle process is evicted after the configured timeout", async () => {
+  const key = `idle-eviction-${Date.now()}`
+  const sessionId = "f8dccdd4-4785-4bd9-8520-7a5993a71f78"
+  let kills = 0
+  setActiveProcess(key, fakeProcess(() => kills++))
+  setClaudeSessionId(key, sessionId)
+
+  scheduleIdleProcessEviction(key, 10)
+  await delay(30)
+
+  assert.equal(kills, 1)
+  assert.equal(getActiveProcess(key), undefined)
+  assert.deepEqual(
+    buildCliArgs({ sessionKey: key, skipPermissions: false }).slice(-2),
+    ["--resume", sessionId],
+  )
+  deleteClaudeSessionId(key)
+})
+
+test("reusing a process cancels its idle eviction", async () => {
+  const key = `idle-reuse-${Date.now()}`
+  let kills = 0
+  const process = fakeProcess(() => kills++)
+  setActiveProcess(key, process)
+
+  scheduleIdleProcessEviction(key, 10)
+  assert.equal(getActiveProcess(key), process)
+  await delay(30)
+
+  assert.equal(kills, 0)
+  assert.equal(getActiveProcess(key), process)
+  deleteActiveProcess(key)
+})
+
+test("timeouts above Node's maximum delay do not evict immediately", async () => {
+  const key = `idle-overflow-${Date.now()}`
+  let kills = 0
+  const process = fakeProcess(() => kills++)
+  setActiveProcess(key, process)
+
+  scheduleIdleProcessEviction(key, 2_147_483_648)
+  await delay(10)
+
+  assert.equal(kills, 0)
+  assert.equal(getActiveProcess(key), process)
+  deleteActiveProcess(key)
+})


### PR DESCRIPTION
## Summary

- add an opt-in `idleProcessTimeoutMs` provider setting for completed headless turns
- cancel eviction when a worker is reused and preserve its session ID for `--resume`
- keep abort, fallback, auto-continuation, tool-call, compaction, and interactive paths out of idle eviction
- make stale process exit/error cleanup ownership-safe
- document the setting and cover eviction, cancellation, resume arguments, overflow, and option propagation

The default remains unchanged: omitted or `0` retains workers until existing LRU eviction.

Closes #16

## Testing

- `npm test` (207 passing)
- `npm run typecheck`
- `npm run build`