### PR TITLE
Require authentication on the proxy MCP endpoint

### DIFF
--- a/src/proxy-mcp.ts
+++ b/src/proxy-mcp.ts
@@ -568,27 +568,53 @@ export async function createProxyMcpServer(
     return crypto.timingSafeEqual(candidate, expectedAuth)
   }
 
+  /**
+   * Reject a request without leaving the connection usable.
+   *
+   * Ending the response alone is not enough. A peer can declare a large
+   * Content-Length, send a single byte, take the rejection, and leave the
+   * request still arriving — and `server.close()` does not reap connections
+   * that are still sending, so a shutdown would hang behind it. Node's
+   * default whole-request timeout is five minutes, which is five minutes of
+   * a socket held by an unauthenticated caller.
+   *
+   * `Connection: close` tells Node to close once the response is flushed;
+   * destroying the socket on `finish` covers the case where the peer never
+   * finishes its body.
+   */
+  function reject(req: IncomingMessage, res: ServerResponse, statusCode: number): void {
+    res.statusCode = statusCode
+    res.setHeader("Connection", "close")
+    res.on("finish", () => {
+      req.socket?.destroy()
+    })
+    res.end()
+  }
+
   const server = createServer(async (req, res) => {
     if (req.method !== "POST" || !req.url?.startsWith("/mcp")) {
-      res.statusCode = 404
-      res.end()
+      reject(req, res, 404)
       return
     }
     // Everything below runs BEFORE readBody: an unauthenticated peer must
     // not be able to stream an unbounded body into memory.
     //
-    // DNS rebinding: a browser rebound onto this port sends the attacker's
-    // hostname in Host, never the loopback authority we generated.
+    // DNS rebinding: a browser rebound onto this port via an attacker
+    // hostname sends that hostname in Host, never the loopback authority we
+    // generated. This does NOT block a page posting directly to
+    // 127.0.0.1:<port> — such a request carries exactly the expected Host —
+    // so it is a rebinding defense specifically, not a browser defense. The
+    // Origin and Content-Type guards below, and the token, cover that case.
     if (req.headers.host !== boundAuthority) {
-      res.statusCode = 403
-      res.end()
+      reject(req, res, 403)
       return
     }
-    // A conforming MCP client sends no Origin. Any Origin at all means the
-    // request came from a browser context, which has no business here.
+    // Claude Code 2.1.226 sends no Origin on MCP requests (verified). The MCP
+    // transport spec obliges SERVERS to validate Origin; it does not oblige
+    // clients to omit it, so this is a measured property of the client we
+    // spawn rather than a guarantee about all conforming clients.
     if (req.headers.origin !== undefined) {
-      res.statusCode = 403
-      res.end()
+      reject(req, res, 403)
       return
     }
     // Requiring application/json forces a CORS preflight for cross-origin
@@ -599,13 +625,11 @@ export async function createProxyMcpServer(
       .trim()
       .toLowerCase()
     if (contentType !== "application/json") {
-      res.statusCode = 415
-      res.end()
+      reject(req, res, 415)
       return
     }
     if (!authOk(req)) {
-      res.statusCode = 401
-      res.end()
+      reject(req, res, 401)
       return
     }
     // Hoist the request id and method so the catch block can echo them

--- a/src/proxy-mcp.ts
+++ b/src/proxy-mcp.ts
@@ -22,6 +22,11 @@ export interface ProxyMcpServer {
   url: string
   serverName: string
   tools: ProxyToolDef[]
+  /** Per-server bearer secret. Minted on start, handed to Claude via the
+   * `headers` block of the generated MCP config, and required on every
+   * request. Exposed so callers (and tests) can authenticate; MUST NOT be
+   * logged or placed in the URL. */
+  authToken: string
   /** Fires when Claude invokes one of our proxy tools. The handler resolves
    * the returned pending call once a result is available. */
   calls: EventEmitter
@@ -541,9 +546,65 @@ export async function createProxyMcpServer(
   const calls = new EventEmitter()
   const pending = new Map<string, ProxyToolCall>()
 
+  // Per-server bearer secret (256 bits). This endpoint executes Bash/Edit/
+  // Write through opencode's executor, so an unauthenticated caller on
+  // loopback would have arbitrary command execution. The token lives only
+  // in this process and in the 0600 MCP config file Claude reads; it is
+  // deliberately kept out of the URL, because query strings leak into logs
+  // and process listings.
+  const authToken = crypto.randomBytes(32).toString("hex")
+  const expectedAuth = Buffer.from(`Bearer ${authToken}`)
+  // The exact authority we hand to Claude. Set once the ephemeral port is
+  // known; compared against the Host header to defeat DNS rebinding.
+  let boundAuthority = ""
+
+  function authOk(req: IncomingMessage): boolean {
+    const got = req.headers.authorization
+    if (typeof got !== "string") return false
+    const candidate = Buffer.from(got)
+    // timingSafeEqual throws on length mismatch, so length-check first.
+    // Length is not secret (the token is fixed-width).
+    if (candidate.length !== expectedAuth.length) return false
+    return crypto.timingSafeEqual(candidate, expectedAuth)
+  }
+
   const server = createServer(async (req, res) => {
     if (req.method !== "POST" || !req.url?.startsWith("/mcp")) {
       res.statusCode = 404
+      res.end()
+      return
+    }
+    // Everything below runs BEFORE readBody: an unauthenticated peer must
+    // not be able to stream an unbounded body into memory.
+    //
+    // DNS rebinding: a browser rebound onto this port sends the attacker's
+    // hostname in Host, never the loopback authority we generated.
+    if (req.headers.host !== boundAuthority) {
+      res.statusCode = 403
+      res.end()
+      return
+    }
+    // A conforming MCP client sends no Origin. Any Origin at all means the
+    // request came from a browser context, which has no business here.
+    if (req.headers.origin !== undefined) {
+      res.statusCode = 403
+      res.end()
+      return
+    }
+    // Requiring application/json forces a CORS preflight for cross-origin
+    // callers (which then fails), closing the text/plain "simple request"
+    // bypass that would otherwise allow blind cross-site POSTs.
+    const contentType = String(req.headers["content-type"] ?? "")
+      .split(";")[0]
+      .trim()
+      .toLowerCase()
+    if (contentType !== "application/json") {
+      res.statusCode = 415
+      res.end()
+      return
+    }
+    if (!authOk(req)) {
+      res.statusCode = 401
       res.end()
       return
     }
@@ -770,8 +831,12 @@ export async function createProxyMcpServer(
     throw new Error("Failed to bind proxy MCP server")
   }
 
-  const url = `http://127.0.0.1:${addr.port}/mcp`
+  boundAuthority = `127.0.0.1:${addr.port}`
+  const url = `http://${boundAuthority}/mcp`
 
+  // NOTE: authToken is deliberately absent from this line and every other
+  // log call. The plugin log is written to disk and echoed to the TUI in
+  // debug mode; a leaked token there would defeat the whole mechanism.
   log.info("proxy-mcp server started", {
     url,
     tools: tools.map((t) => t.name),
@@ -783,6 +848,7 @@ export async function createProxyMcpServer(
     url,
     serverName: SERVER_NAME,
     tools,
+    authToken,
     calls,
     configPath() {
       if (configFilePath) return configFilePath
@@ -792,6 +858,10 @@ export async function createProxyMcpServer(
             [SERVER_NAME]: {
               type: "http",
               url,
+              // Claude CLI replays these headers on every request to this
+              // server, which is what lets the handler above reject anyone
+              // who did not read this 0600 file.
+              headers: { Authorization: `Bearer ${authToken}` },
               timeout: resolveProxyClientCeilingMs(timeoutOverrides),
             },
           },

--- a/test-proxy-mcp.ts
+++ b/test-proxy-mcp.ts
@@ -618,13 +618,62 @@ test("security: the generated MCP config carries the token, 0600, and never in t
     assert.equal(entry.type, "http")
     assert.equal(entry.headers.Authorization, `Bearer ${srv.authToken}`)
 
-    // The file now holds a secret, so its mode is load-bearing.
-    assert.equal(fs.statSync(cfgPath).mode & 0o777, 0o600)
+    // The file now holds a secret, so its mode is load-bearing -- ON POSIX.
+    // Node does not implement owner/group/other mode bits on Windows, where
+    // this commonly reads back 0o666 and confidentiality instead depends on
+    // the inherited ACL of os.tmpdir(). Asserting 0o600 there would be a
+    // test that cannot pass, and claiming it in the README would be a
+    // guarantee we do not provide.
+    if (process.platform !== "win32") {
+      assert.equal(fs.statSync(cfgPath).mode & 0o777, 0o600)
+    }
 
     // A token in the URL would leak into logs and process listings.
     assert.ok(!srv.url.includes(srv.authToken))
     assert.ok(!entry.url.includes(srv.authToken))
   })
+})
+
+// A rejected request must not leave the connection usable. Without an
+// explicit close, a peer can declare a large Content-Length, send one byte,
+// take the 401, and hold the socket -- and `server.close()` does NOT reap
+// connections that are still sending, so shutdown would block behind an
+// unauthenticated caller for Node's five-minute request timeout.
+//
+// This test deliberately never finishes the body. An earlier version of the
+// suite masked the defect by destroying the socket client-side as soon as the
+// response arrived, which is exactly the cleanup the server must not depend on.
+test("security: rejecting an unauthenticated request does not leave shutdown hostage to an unfinished body", async () => {
+  const net = await import("node:net")
+  const srv = await createProxyMcpServer(DEFAULT_PROXY_TOOLS)
+  const { port } = new URL(srv.url)
+
+  const sock = net.connect({ host: "127.0.0.1", port: Number(port) })
+  await new Promise<void>((resolve) => sock.once("connect", () => resolve()))
+
+  // Announce a large body, then send a single byte and stop.
+  sock.write(
+    "POST /mcp HTTP/1.1\r\n" +
+      `Host: 127.0.0.1:${port}\r\n` +
+      "Content-Type: application/json\r\n" +
+      "Content-Length: 1048576\r\n" +
+      "\r\n" +
+      "{",
+  )
+
+  const status = await new Promise<string>((resolve) => {
+    sock.once("data", (chunk) => resolve(chunk.toString("utf8").split("\r\n")[0]))
+  })
+  assert.match(status, /401/, "the unauthenticated request should be rejected")
+
+  // The body is still unfinished here, on purpose. close() must not hang.
+  const closed = srv.close().then(() => "closed" as const)
+  const timedOut = new Promise<"hung">((resolve) =>
+    setTimeout(() => resolve("hung"), 4000).unref(),
+  )
+  assert.equal(await Promise.race([closed, timedOut]), "closed")
+
+  sock.destroy()
 })
 
 test("security: a client using only the generated config's header is accepted (round-trip)", async () => {

--- a/test-proxy-mcp.ts
+++ b/test-proxy-mcp.ts
@@ -11,6 +11,7 @@
 import assert from "node:assert/strict"
 import { test } from "node:test"
 import * as http from "node:http"
+import * as fs from "node:fs"
 import {
   createProxyMcpServer,
   buildProxyTimeoutError,
@@ -26,17 +27,27 @@ import {
   type ProxyToolResult,
 } from "./src/proxy-mcp.js"
 
-function post(url: string, body: unknown): Promise<{
+/**
+ * Low-level POST. `headers` REPLACES the default header set, so the
+ * security tests below can omit Authorization, send a foreign Host, add an
+ * Origin, or use a non-JSON Content-Type. `rawBody` bypasses JSON encoding
+ * for the malformed-payload case.
+ */
+function post(
+  url: string,
+  body: unknown,
+  opts: { headers?: Record<string, string>; rawBody?: string } = {},
+): Promise<{
   status: number
   json: any
 }> {
   return new Promise((resolve, reject) => {
-    const payload = JSON.stringify(body)
+    const payload = opts.rawBody ?? JSON.stringify(body)
     const req = http.request(
       url,
       {
         method: "POST",
-        headers: {
+        headers: opts.headers ?? {
           "Content-Type": "application/json",
           "Content-Length": Buffer.byteLength(payload).toString(),
         },
@@ -57,6 +68,18 @@ function post(url: string, body: unknown): Promise<{
     req.on("error", reject)
     req.write(payload)
     req.end()
+  })
+}
+
+/** The happy path: a correctly authenticated JSON-RPC POST. */
+function authedPost(srv: ProxyMcpServer, body: unknown) {
+  const payload = JSON.stringify(body)
+  return post(srv.url, body, {
+    headers: {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(payload).toString(),
+      Authorization: `Bearer ${srv.authToken}`,
+    },
   })
 }
 
@@ -84,7 +107,7 @@ test("tools/call broker rejection returns an MCP result with isError, echoing th
       call.reject(new Error("simulated broker rejection"))
     })
 
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: 42,
       method: "tools/call",
@@ -114,7 +137,7 @@ test("tools/call with kind:error result returns an MCP result with isError", asy
       call.resolve(result)
     })
 
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: "req-7",
       method: "tools/call",
@@ -133,7 +156,7 @@ test("tools/call with kind:error result returns an MCP result with isError", asy
 
 test("tools/call for an unknown tool returns an MCP result with isError", async () => {
   await withServer(async (srv) => {
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: 99,
       method: "tools/call",
@@ -151,7 +174,7 @@ test("tools/call success preserves isError:false and the result text", async () 
     srv.calls.on("call", (call: ProxyToolCall) => {
       call.resolve({ kind: "text", text: "done" })
     })
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: 3,
       method: "tools/call",
@@ -164,36 +187,16 @@ test("tools/call success preserves isError:false and the result text", async () 
 
 test("malformed JSON still responds (with null id when unparseable)", async () => {
   await withServer(async (srv) => {
-    // Send invalid JSON so parsing throws before requestId is set.
-    const res = await new Promise<{
-      status: number
-      json: any
-    }>((resolve, reject) => {
-      const req = http.request(
-        srv.url,
-        {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Content-Length": Buffer.byteLength("{not json").toString(),
-          },
-        },
-        (r) => {
-          const chunks: Buffer[] = []
-          r.on("data", (c: Buffer) => chunks.push(c))
-          r.on("end", () => {
-            const text = Buffer.concat(chunks).toString("utf8")
-            try {
-              resolve({ status: r.statusCode ?? 0, json: JSON.parse(text) })
-            } catch {
-              resolve({ status: r.statusCode ?? 0, json: text })
-            }
-          })
-        },
-      )
-      req.on("error", reject)
-      req.write("{not json")
-      req.end()
+    // Send invalid JSON so parsing throws before requestId is set. The
+    // request is otherwise well-formed and authenticated, so it reaches
+    // the parser rather than being rejected by the entry guards.
+    const res = await post(srv.url, null, {
+      rawBody: "{not json",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength("{not json").toString(),
+        Authorization: `Bearer ${srv.authToken}`,
+      },
     })
 
     // When the body never parsed, null id is the only honest answer and
@@ -205,7 +208,7 @@ test("malformed JSON still responds (with null id when unparseable)", async () =
 
 test("tools/list exposes the default proxy defs", async () => {
   await withServer(async (srv) => {
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: 1,
       method: "tools/list",
@@ -350,7 +353,7 @@ test("tools/call timeout uses the per-tool override and surfaces the task-specif
   const srv = await createProxyMcpServer(DEFAULT_PROXY_TOOLS, { task: 50 })
   try {
     // Intentionally do NOT attach a calls listener — let the deadline fire.
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: "timeout-1",
       method: "tools/call",
@@ -384,7 +387,7 @@ test("tools/call bash timeout honours input.timeout over a shorter override", as
         call.resolve({ kind: "text", text: "built" })
       }, 120)
     })
-    const res = await post(srv.url, {
+    const res = await authedPost(srv, {
       jsonrpc: "2.0",
       id: "bash-1",
       method: "tools/call",
@@ -449,4 +452,208 @@ test("overlayQuestionProxyDescription is a no-op without a live description", ()
     undefined,
   ).find((t) => t.name === "question")
   assert.equal(after?.description, before?.description)
+})
+
+// ---------------------------------------------------------------------------
+// Entry-guard security tests.
+//
+// This endpoint executes bash/edit/write through opencode's executor, so an
+// unauthenticated caller on loopback would have arbitrary command execution
+// as the user. These pin every guard in front of the JSON-RPC body parser.
+// ---------------------------------------------------------------------------
+
+const LIST_REQ = { jsonrpc: "2.0", id: 1, method: "tools/list" }
+
+function jsonHeaders(
+  payload: string,
+  extra: Record<string, string> = {},
+): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    "Content-Length": Buffer.byteLength(payload).toString(),
+    ...extra,
+  }
+}
+
+test("security: a correctly authenticated request is accepted", async () => {
+  await withServer(async (srv) => {
+    const res = await authedPost(srv, LIST_REQ)
+    assert.equal(res.status, 200)
+    assert.ok(res.json.result.tools.length > 0)
+  })
+})
+
+test("security: a wrong bearer token of equal length is rejected with 401", async () => {
+  await withServer(async (srv) => {
+    // Same length as the real token, so this exercises timingSafeEqual
+    // rather than the cheap length short-circuit in front of it.
+    const forged = "0".repeat(srv.authToken.length)
+    assert.equal(forged.length, srv.authToken.length)
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, { Authorization: `Bearer ${forged}` }),
+    })
+    assert.equal(res.status, 401)
+  })
+})
+
+test("security: a short/garbage bearer token is rejected with 401", async () => {
+  await withServer(async (srv) => {
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, { Authorization: "Bearer nope" }),
+    })
+    assert.equal(res.status, 401)
+  })
+})
+
+test("security: an absent Authorization header is rejected with 401", async () => {
+  await withServer(async (srv) => {
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, { headers: jsonHeaders(payload) })
+    assert.equal(res.status, 401)
+  })
+})
+
+test("security: a foreign Host header is rejected with 403 (DNS rebinding)", async () => {
+  await withServer(async (srv) => {
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, {
+        Host: "attacker.example",
+        Authorization: `Bearer ${srv.authToken}`,
+      }),
+    })
+    assert.equal(res.status, 403)
+  })
+})
+
+test("security: any Origin header is rejected with 403 (browser context)", async () => {
+  await withServer(async (srv) => {
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, {
+        Origin: "https://attacker.example",
+        Authorization: `Bearer ${srv.authToken}`,
+      }),
+    })
+    assert.equal(res.status, 403)
+  })
+})
+
+test("security: text/plain is rejected with 415 (CORS simple-request bypass)", async () => {
+  await withServer(async (srv) => {
+    // text/plain is a CORS "simple request" content type, so a cross-origin
+    // page can send it with no preflight. Requiring application/json forces
+    // a preflight that then fails.
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: {
+        "Content-Type": "text/plain",
+        "Content-Length": Buffer.byteLength(payload).toString(),
+        Authorization: `Bearer ${srv.authToken}`,
+      },
+    })
+    assert.equal(res.status, 415)
+  })
+})
+
+test("security: a Content-Type with charset parameters is still accepted", async () => {
+  await withServer(async (srv) => {
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, {
+        "Content-Type": "application/json; charset=utf-8",
+        Authorization: `Bearer ${srv.authToken}`,
+      }),
+    })
+    assert.equal(res.status, 200)
+  })
+})
+
+test("security: the 401 path answers without reading the request body", async () => {
+  await withServer(async (srv) => {
+    const status = await new Promise<number>((resolve, reject) => {
+      const req = http.request(
+        srv.url,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            // Declare a large body that we never finish sending, and send
+            // no Authorization. If the handler read the body before
+            // authenticating it would block here and no response would
+            // ever arrive.
+            "Content-Length": "10000000",
+          },
+        },
+        (res) => {
+          clearTimeout(timer)
+          res.resume()
+          resolve(res.statusCode ?? 0)
+          req.destroy()
+        },
+      )
+      const timer = setTimeout(() => {
+        req.destroy()
+        reject(
+          new Error(
+            "no response while the body was still incomplete — the handler appears to read the body before authenticating",
+          ),
+        )
+      }, 5000)
+      req.on("error", () => {})
+      req.write("{") // one byte; req.end() is deliberately never called
+    })
+    assert.equal(status, 401)
+  })
+})
+
+test("security: the generated MCP config carries the token, 0600, and never in the URL", async () => {
+  await withServer(async (srv) => {
+    const cfgPath = srv.configPath()
+    const cfg = JSON.parse(fs.readFileSync(cfgPath, "utf8"))
+    const entry = cfg.mcpServers[srv.serverName]
+
+    assert.equal(entry.type, "http")
+    assert.equal(entry.headers.Authorization, `Bearer ${srv.authToken}`)
+
+    // The file now holds a secret, so its mode is load-bearing.
+    assert.equal(fs.statSync(cfgPath).mode & 0o777, 0o600)
+
+    // A token in the URL would leak into logs and process listings.
+    assert.ok(!srv.url.includes(srv.authToken))
+    assert.ok(!entry.url.includes(srv.authToken))
+  })
+})
+
+test("security: a client using only the generated config's header is accepted (round-trip)", async () => {
+  await withServer(async (srv) => {
+    // Proves config generation and request validation agree: read the
+    // header out of the file Claude is handed, and use nothing else.
+    const cfg = JSON.parse(fs.readFileSync(srv.configPath(), "utf8"))
+    const auth = cfg.mcpServers[srv.serverName].headers.Authorization
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(srv.url, LIST_REQ, {
+      headers: jsonHeaders(payload, { Authorization: auth }),
+    })
+    assert.equal(res.status, 200)
+    assert.ok(res.json.result.tools.length > 0)
+  })
+})
+
+test("security: two servers get distinct tokens, and one's token is rejected by the other", async () => {
+  const a = await createProxyMcpServer(DEFAULT_PROXY_TOOLS)
+  const b = await createProxyMcpServer(DEFAULT_PROXY_TOOLS)
+  try {
+    assert.notEqual(a.authToken, b.authToken)
+    const payload = JSON.stringify(LIST_REQ)
+    const res = await post(b.url, LIST_REQ, {
+      headers: jsonHeaders(payload, { Authorization: `Bearer ${a.authToken}` }),
+    })
+    assert.equal(res.status, 401)
+  } finally {
+    await a.close()
+    await b.close()
+  }
 })

--- a/test-proxy-task.ts
+++ b/test-proxy-task.ts
@@ -19,6 +19,7 @@ import {
   isExpectedCleanupError,
   resolveProxyClientCeilingMs,
   SERVER_CLOSED_MESSAGE,
+  type ProxyMcpServer,
 } from "./src/proxy-mcp.js"
 import {
   getPendingProxyCalls,
@@ -78,13 +79,18 @@ if (process.argv.includes("--version")) {
 const args = process.argv.slice(2)
 const configIndex = args.indexOf("--mcp-config")
 let proxyUrl
+let proxyHeaders = {}
 if (configIndex >= 0) {
   for (let index = configIndex + 1; index < args.length; index++) {
     const value = args[index]
     if (value.startsWith("--")) break
     try {
       const config = JSON.parse(fs.readFileSync(value, "utf8"))
-      proxyUrl = config.mcpServers?.opencode_proxy?.url ?? proxyUrl
+      const entry = config.mcpServers?.opencode_proxy
+      proxyUrl = entry?.url ?? proxyUrl
+      // A real MCP client replays the configured headers on every request;
+      // the proxy server requires its bearer token, so do the same here.
+      proxyHeaders = entry?.headers ?? proxyHeaders
     } catch {}
   }
 }
@@ -222,7 +228,7 @@ function emitAssistant() {
 async function callTask(input = taskInput, id = 1) {
   const response = await fetch(proxyUrl, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...proxyHeaders },
     body: JSON.stringify({
       jsonrpc: "2.0",
       id,
@@ -375,10 +381,17 @@ function assertNativeTaskBoundary(
   )
 }
 
-async function postRpc(url: string, request: Record<string, unknown>) {
-  const response = await fetch(url, {
+async function postRpc(
+  srv: ProxyMcpServer,
+  request: Record<string, unknown>,
+) {
+  const response = await fetch(srv.url, {
     method: "POST",
-    headers: { "content-type": "application/json" },
+    headers: {
+      "content-type": "application/json",
+      // The proxy endpoint requires the per-server bearer token.
+      authorization: `Bearer ${srv.authToken}`,
+    },
     body: JSON.stringify(request),
   })
   if (response.status === 204) return { status: 204, body: null }
@@ -511,7 +524,7 @@ test("proxy MCP initializes, lists Task, and resolves it through the broker", as
     )
     assert.equal(resolveProxyClientCeilingMs(undefined), 60 * 60 * 1000)
 
-    const initialized = await postRpc(server.url, {
+    const initialized = await postRpc(server, {
       jsonrpc: "2.0",
       id: "initialize-1",
       method: "initialize",
@@ -524,13 +537,13 @@ test("proxy MCP initializes, lists Task, and resolves it through the broker", as
     assert.equal(initialized.body.id, "initialize-1")
     assert.equal(initialized.body.result.serverInfo.name, "opencode_proxy")
 
-    const notification = await postRpc(server.url, {
+    const notification = await postRpc(server, {
       jsonrpc: "2.0",
       method: "notifications/initialized",
     })
     assert.equal(notification.status, 204)
 
-    const listed = await postRpc(server.url, {
+    const listed = await postRpc(server, {
       jsonrpc: "2.0",
       id: "list-1",
       method: "tools/list",
@@ -542,7 +555,7 @@ test("proxy MCP initializes, lists Task, and resolves it through the broker", as
     )
 
     const brokerCalls = waitForBrokerCalls(brokerSession, 1)
-    const callResponse = postRpc(server.url, {
+    const callResponse = postRpc(server, {
       jsonrpc: "2.0",
       id: "task-1",
       method: "tools/call",
@@ -604,7 +617,7 @@ test("closing the server rejects a pending call with the cleanup message", async
   const callReceived = new Promise<void>((resolve) => {
     server.calls.once("call", () => resolve())
   })
-  const callResponse = postRpc(server.url, {
+  const callResponse = postRpc(server, {
     jsonrpc: "2.0",
     id: "close-1",
     method: "tools/call",
@@ -638,7 +651,7 @@ test("parallel proxy calls preserve success and error correlation", async () => 
     ]
     const brokerCalls = waitForBrokerCalls(brokerSession, inputs.length)
     const responses = inputs.map((input, index) =>
-      postRpc(server.url, {
+      postRpc(server, {
         jsonrpc: "2.0",
         id: `batch-${index}`,
         method: "tools/call",


### PR DESCRIPTION
## Require authentication on the proxy MCP endpoint

### The problem


The practical consequence is that anything able to reach the port can execute arbitrary commands as the user, through opencode's own executor. Any local process can enumerate loopback listeners and post to it. A browser vector also exists: because `Content-Type` is not validated, a page can send a CORS "simple request" with `text/plain`, which requires no preflight. The attacker cannot read the response, since no CORS headers are set, but does not need to — the command still runs. The ephemeral port is the only obstacle, and a 16-bit space is scannable.


I found this while auditing the plugin before adopting it. This is not a theoretical concern — the endpoint is unauthenticated as shipped in 0.12.0.

### The fix





### Compatibility

No configuration change is required and no user-facing behaviour changes. The token is generated, written and consumed entirely inside the plugin. `ProxyMcpServer` gains one field, `authToken`, so callers and tests can authenticate; nothing else in the interface moves. The config file continues to be written `0600`, which matters more now that it holds the secret, so there is a test pinning that mode — gated to POSIX. Node does not implement owner/group/other mode bits on Windows, where the same call commonly reads back `0666` and confidentiality instead rests on the inherited ACL of `os.tmpdir()`. I have not tested on Windows and am not claiming a guarantee there; if you want one, it would need an explicit ACL rather than a mode.

### Tests

No new test file was added, so the `package.json` test-script enumeration is untouched and there is nothing that can silently fail to run. `test-proxy-mcp.ts` goes from 24 to 37 tests, and `test-proxy-task.ts` was updated because it drives the endpoint two different ways and both were unauthenticated.

The thirteen new tests cover: a valid token is accepted; a wrong token of identical length is rejected 401, which exercises `timingSafeEqual` rather than the length short-circuit in front of it; a short garbage token is rejected 401; an absent `Authorization` header is rejected 401; a foreign `Host` is rejected 403; any `Origin` is rejected 403; `text/plain` is rejected 415; `application/json; charset=utf-8` is still accepted, so the parameter stripping is not over-strict; the 401 path answers while the request body is still incomplete, which pins the auth-before-read ordering; the generated config carries the token, is mode 0600, and never puts the token in the URL; a client using only the header read back out of the generated config file is accepted, round-tripping config generation against request validation; two concurrent servers get distinct tokens, with one rejecting the other's; and a rejected request does not leave `server.close()` hanging behind a body the peer never finishes sending.


I verified these tests actually fail when the guard is removed rather than merely passing. With the auth check commented out, five of them fail, including the body-ordering test, which times out at five seconds because the handler blocks reading a body that never finishes. The `Host`, `Origin` and `Content-Type` tests correctly stay green in that run, since those guards are independent of the token. The connection-closing test was checked the same way and separately: with only the `Connection: close` and socket teardown removed, it fails at four seconds instead of passing in four milliseconds, so it is measuring the shutdown behaviour rather than restating the 401.

`npm run typecheck`, `npm test` and `npm run build` all pass.

One disclosure on the suite, which I want to state carefully because my first attempt at measuring it was wrong. The four native-tool-boundary tests in `test-proxy-task.ts` use 25ms and 50ms timers and are sensitive to machine load. My initial trial suggested this branch flaked and master did not; that trial was invalid, because a `git checkout` had been silently blocked and both arms were running the same tree. I caught it only because the reported test count (294 on master versus 306 here) disagreed with which tree I thought I was testing.

Redone properly with two independent trees, ten paired runs each, the picture is different and more useful to you: master flaked 4 times out of 10 and this branch 7 out of 10, on the same two assertions (`result before delayed Task call still closes on native tool boundary` and `parallel Task calls drain in one native tool boundary`). **The flakiness is pre-existing on master and is not introduced by this patch.** Whether the branch is genuinely worse I cannot say — ten runs per arm does not separate 7/10 from 4/10 with any confidence, and the plausible mechanism is that thirteen extra tests add parallel load rather than that the guards add latency, since they cost microseconds against a 25ms window. No security test failed in any run on either tree. Flagging all of it rather than reporting a clean sweep, in case you would rather those timers were less tight.

### What this does not close

A local process running as the same user can read the config file and use the token — on POSIX, where `0600` is what stands between them and it; on Windows, whatever ACL `os.tmpdir()` confers. That is not closable from inside the plugin, and it is the correct boundary: an attacker already executing code as your user can run commands directly and does not need this endpoint. The point of the change is that reaching the endpoint should require at least as much privilege as the endpoint grants, which is not true today.

I considered moving the transport to stdio, which would remove the port entirely. It does not fit the architecture: a stdio MCP server is spawned as a subprocess by the client, and this server has to live inside the opencode process because the broker it hands calls to is in-process state. It could be done with a relay shim over a unix socket, but that is a much larger change for the same residual risk against a same-uid attacker, so a token seemed the right size of fix. Happy to go that way instead if you would prefer it.
